### PR TITLE
Persistent Storage

### DIFF
--- a/src/codeu/chat/ClientMain.java
+++ b/src/codeu/chat/ClientMain.java
@@ -15,6 +15,7 @@
 package codeu.chat;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 

--- a/src/codeu/chat/ClientMain.java
+++ b/src/codeu/chat/ClientMain.java
@@ -22,12 +22,16 @@ import codeu.chat.client.commandline.Chat;
 import codeu.chat.client.core.Context;
 import codeu.chat.util.Logger;
 import codeu.chat.util.RemoteAddress;
+import codeu.chat.util.Time;
 import codeu.chat.util.connections.ClientConnectionSource;
 import codeu.chat.util.connections.ConnectionSource;
 
 final class ClientMain {
 
   private static final Logger.Log LOG = Logger.newLog(ClientMain.class);
+
+  private static Time lastLogBackup;
+  private static final long BACKUP_RATE_IN_MS = 30000;
 
   public static void main(String [] args) {
 
@@ -52,9 +56,20 @@ final class ClientMain {
 
     boolean keepRunning = true;
 
+    lastLogBackup = Time.now();
+
     try (final BufferedReader input = new BufferedReader(new InputStreamReader(System.in))) {
       while (keepRunning) {
         System.out.print(">>> ");
+
+        // Evaluate if it is time to transfer data from queue to disk, then call the transferQueueToLog() method defined
+        // above and update the last backup time
+        Time currentTime = Time.now();
+        if(currentTime.inMs() - lastLogBackup.inMs() >= BACKUP_RATE_IN_MS){
+          chat.transferQueueToLog();
+          lastLogBackup = currentTime;
+        }
+
         keepRunning = chat.handleCommand(input.readLine().trim());
       }
     } catch (IOException ex) {

--- a/src/codeu/chat/ServerMain.java
+++ b/src/codeu/chat/ServerMain.java
@@ -61,6 +61,7 @@ final class ServerMain {
       port = Integer.parseInt(args[2]);
       persistentPath = new File(args[3]);
       relayAddress = args.length > 4 ? RemoteAddress.parse(args[4]) : null;
+      System.out.println("meow");
     } catch (Exception ex) {
       LOG.error(ex, "Failed to read command arguments");
       System.exit(1);

--- a/src/codeu/chat/ServerMain.java
+++ b/src/codeu/chat/ServerMain.java
@@ -102,7 +102,6 @@ final class ServerMain {
     while (true) {
 
       try {
-
         LOG.info("Established connection...");
         final Connection connection = serverSource.connect();
         LOG.info("Connection established.");

--- a/src/codeu/chat/ServerMain.java
+++ b/src/codeu/chat/ServerMain.java
@@ -61,7 +61,6 @@ final class ServerMain {
       port = Integer.parseInt(args[2]);
       persistentPath = new File(args[3]);
       relayAddress = args.length > 4 ? RemoteAddress.parse(args[4]) : null;
-      System.out.println("meow");
     } catch (Exception ex) {
       LOG.error(ex, "Failed to read command arguments");
       System.exit(1);

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -81,9 +81,12 @@ public final class Chat {
 
     // TODO: Parse the log data, and create users/conversations/messages as necessary
     while(headLine != null && dataLine != null){
-
+      //holds default log String
       headLine = bufferedReader.readLine();
+      //holds what was inserted into log (what's parsed)
       dataLine = bufferedReader.readLine();
+
+
     }
 
   }
@@ -211,7 +214,7 @@ public final class Chat {
           if (user == null) {
             System.out.println("ERROR: Failed to create new user");
           } else {
-            transactionLog.add(String.format("ADD-USER id: %s, username: %s, time: %s",
+            transactionLog.add(String.format("ADD-USER %s %s %s", //command user-id username creation-time
                                 user.user.id, user.user.name, user.user.creation));
             LOG.info(String.format("ADD-USER %s %s %s", user.user.id, user.user.name, user.user.creation));
           }
@@ -238,8 +241,8 @@ public final class Chat {
             System.out.format("ERROR: Failed to sign in as '%s'\n", name);
           } else {
             panels.push(createUserPanel(user));
-            transactionLog.add(String.format("SIGN-IN-USER id: %s, username: %s, time: %s",
-                                user.user.id, user.user.name, user.user.creation));
+                                              //command user-id username creation-time
+            transactionLog.add(String.format("SIGN-IN-USER %s %s %s", user.user.id, user.user.name, user.user.creation));
             LOG.info(String.format("SIGN-IN-USER %s %s %s", user.user.id, user.user.name, user.user.creation));
           }
         } else {
@@ -339,9 +342,8 @@ public final class Chat {
             System.out.println("ERROR: Failed to create new conversation");
           } else {
             panels.push(createConversationPanel(conversation));
-            transactionLog.add(String.format("ADD-CONSERVATION id: %s, owner: %s, title: %s, time: %s",
-                            conversation.conversation.id, conversation.conversation.owner,
-                            conversation.conversation.title, conversation.conversation.creation));
+            transactionLog.add(String.format("ADD-CONVERSATION %s %s %s %s", conversation.conversation.id, conversation.conversation.owner,
+                    conversation.conversation.title, conversation.conversation.creation)); //command convo-id convo-owner convo-title creation-time
             LOG.info(String.format("ADD-CONVERSATION %s %s %s %s", conversation.conversation.id, conversation.conversation.owner,
                     conversation.conversation.title, conversation.conversation.creation));
           }
@@ -366,9 +368,8 @@ public final class Chat {
             System.out.format("ERROR: No conversation with name '%s'\n", name);
           } else {
             panels.push(createConversationPanel(conversation));
-            transactionLog.add(String.format("JOIN-CONSERVATION id: %s, owner: %s, title: %s, time: %s",
-                    conversation.conversation.id, conversation.conversation.owner,
-                    conversation.conversation.title, conversation.conversation.creation));
+            transactionLog.add(String.format("JOIN-CONVERSATION %s %s %s %s", conversation.conversation.id, conversation.conversation.owner,
+                    conversation.conversation.title, conversation.conversation.creation)); //command convo-id convo-owner convo-title creation-time
             LOG.info(String.format("JOIN-CONVERSATION %s %s %s %s", conversation.conversation.id, conversation.conversation.owner,
                     conversation.conversation.title, conversation.conversation.creation));
           }
@@ -468,9 +469,8 @@ public final class Chat {
         final String message = args.size() > 0 ? args.get(0) : "";
         if (message.length() > 0) {
           MessageContext messageContext = conversation.add(message);
-          transactionLog.add(String.format("ADD-MESSAGE id: %s, author: %s, content: %s, time: %s",
-                  messageContext.message.id, messageContext.message.author,
-                  messageContext.message.content, messageContext.message.creation));
+          transactionLog.add(String.format("ADD-MESSAGE %s %s %s %s", messageContext.message.id, messageContext.message.author,
+                  messageContext.message.content, messageContext.message.creation)); //command message-id message-author message-content creation-time
           LOG.info(String.format("ADD-MESSAGE %s %s %s %s", messageContext.message.id, messageContext.message.author,
                   messageContext.message.content, messageContext.message.creation));
         } else {

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -56,8 +56,7 @@ public final class Chat {
 
     try {
       // Create a new transaction_log.txt file if needed - if not, this command does nothing
-      if(!logFile.createNewFile())
-        System.out.println("Successfully restored last logged server state.");
+      logFile.createNewFile();
 
       // Open the file as a PrintWriter and set file writing options to append
       pw_log = new PrintWriter(new BufferedWriter(new FileWriter("data/transaction_log.txt", true)));

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -71,9 +71,8 @@ public final class Chat {
   private void transferQueueToLog(){
     while(!transactionLog.isEmpty()){
       pw_log.println(transactionLog.pop());
-      pw_log.flush();
     }
-
+    pw_log.flush();
   }
 
   // HANDLE COMMAND
@@ -199,7 +198,7 @@ public final class Chat {
     panel.register("u-add", new Panel.Command() {
       @Override
       public void invoke(List<String> args) {
-        final String name = args.size() > 0 ? String.join(" ", args.subList(0, args.size())) : "";
+        final String name = args.size() > 0 ? String.join(" ", args) : "";
         final UserContext user = context.create(name);
 
         if (name.length() > 0) {
@@ -230,7 +229,7 @@ public final class Chat {
     panel.register("u-sign-in", new Panel.Command() {
       @Override
       public void invoke(List<String> args) {
-        final String name = args.size() > 0 ? String.join(" ", args.subList(0, args.size())) : "";
+        final String name = args.size() > 0 ? String.join(" ", args) : "";
         if (name.length() > 0) {
           final UserContext user = findUser(name);
           if (user == null) {
@@ -328,7 +327,7 @@ public final class Chat {
     panel.register("c-add", new Panel.Command() {
       @Override
       public void invoke(List<String> args) {
-        final String name = args.size() > 0 ? String.join(" ", args.subList(0, args.size())) : "";
+        final String name = args.size() > 0 ? String.join(" ", args) : "";
         if (name.length() > 0) {
           final ConversationContext conversation = user.start(name);
           if (conversation == null) {
@@ -358,7 +357,7 @@ public final class Chat {
     panel.register("c-join", new Panel.Command() {
       @Override
       public void invoke(List<String> args) {
-        final String name = args.size() > 0 ? String.join(" ", args.subList(0, args.size())) : "";
+        final String name = args.size() > 0 ? String.join(" ", args) : "";
         if (name.length() > 0) {
           final ConversationContext conversation = find(name);
           if (conversation == null) {
@@ -459,7 +458,7 @@ public final class Chat {
     panel.register("m-add", new Panel.Command() {
       @Override
       public void invoke(List<String> args) {
-        final String message = args.size() > 0 ? String.join(" ", args.subList(0, args.size())) : "";
+        final String message = args.size() > 0 ? String.join(" ", args) : "";
         if (message.length() > 0) {
           MessageContext messageContext = conversation.add(message);
           transactionLog.add(String.format("ADD-MESSAGE %s %s %s \"%s\" %s",

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -145,7 +145,7 @@ public final class Chat {
       public void invoke(List<String> args) {
         for (final UserContext user : context.allUsers()) {
           System.out.format(
-              "USER %s (UUID:%s)\n",
+              "USER %s (UUID: %s)\n",
               user.user.name,
               user.user.id);
         }
@@ -167,7 +167,7 @@ public final class Chat {
           if (user == null) {
             System.out.println("ERROR: Failed to create new user");
           } else {
-            LOG.info("ADD-USER " + user.user.id + " \"" + user.user.name + "\" " + user.user.creation);
+            LOG.info(String.format("ADD-USER %s %s %s", user.user.id, user.user.name, user.user.creation));
           }
         } else {
           System.out.println("ERROR: Missing <username>");
@@ -192,7 +192,7 @@ public final class Chat {
             System.out.format("ERROR: Failed to sign in as '%s'\n", name);
           } else {
             panels.push(createUserPanel(user));
-            LOG.info("SIGN-IN-USER " + user.user.id + " \"" + user.user.name + "\" " + user.user.creation);
+            LOG.info(String.format("SIGN-IN-USER %s %s %s", user.user.id, user.user.name, user.user.creation));
           }
         } else {
           System.out.println("ERROR: Missing <username>");
@@ -269,7 +269,7 @@ public final class Chat {
       public void invoke(List<String> args) {
         for (final ConversationContext conversation : user.conversations()) {
           System.out.format(
-              "CONVERSATION %s (UUID:%s)\n",
+              "CONVERSATION %s (UUID: %s)\n",
               conversation.conversation.title,
               conversation.conversation.id);
         }
@@ -291,7 +291,8 @@ public final class Chat {
             System.out.println("ERROR: Failed to create new conversation");
           } else {
             panels.push(createConversationPanel(conversation));
-            LOG.info("ADD-CONVERSATION " + conversation.conversation.id + " \"" + conversation.conversation.title + "\" " + conversation.conversation.creation + " " + conversation.conversation.owner);
+            LOG.info(String.format("ADD-CONVERSATION %s %s %s %s", conversation.conversation.id, conversation.conversation.owner,
+                    conversation.conversation.title, conversation.conversation.creation));
           }
         } else {
           System.out.println("ERROR: Missing <title>");
@@ -314,7 +315,8 @@ public final class Chat {
             System.out.format("ERROR: No conversation with name '%s'\n", name);
           } else {
             panels.push(createConversationPanel(conversation));
-            LOG.info("JOIN-CONVERSATION " + conversation.conversation.id + " \"" + conversation.conversation.title + "\" ");
+            LOG.info(String.format("ADD-CONVERSATION %s %s %s %s", conversation.conversation.id, conversation.conversation.owner,
+                    conversation.conversation.title, conversation.conversation.creation));
           }
         } else {
           System.out.println("ERROR: Missing <title>");
@@ -343,7 +345,7 @@ public final class Chat {
       public void invoke(List<String> args) {
         System.out.println("User Info:");
         System.out.format("  Name : %s\n", user.user.name);
-        System.out.format("  Id   : UUID:%s\n", user.user.id);
+        System.out.format("  Id   : UUID: %s\n", user.user.id);
       }
     });
 
@@ -411,8 +413,9 @@ public final class Chat {
       public void invoke(List<String> args) {
         final String message = args.size() > 0 ? args.get(0) : "";
         if (message.length() > 0) {
-          conversation.add(message);
-          LOG.info("ADD-MESSAGE " + conversation.user.creation + " \"" + message + "\"");
+          MessageContext messageContext = conversation.add(message);
+          LOG.info(String.format("ADD-MESSAGE %s %s %s %s", messageContext.message.id, messageContext.message.author,
+                  messageContext.message.content, messageContext.message.creation));
         } else {
           System.out.println("ERROR: Messages must contain text");
         }
@@ -429,7 +432,7 @@ public final class Chat {
       public void invoke(List<String> args) {
         System.out.println("Conversation Info:");
         System.out.format("  Title : %s\n", conversation.conversation.title);
-        System.out.format("  Id    : UUID:%s\n", conversation.conversation.id);
+        System.out.format("  Id    : UUID: %s\n", conversation.conversation.id);
         System.out.format("  Owner : %s\n", conversation.conversation.owner);
       }
     });

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -30,9 +30,6 @@ public final class Chat {
   private static final File logFile = new File("data/transaction_log.txt");
   private static PrintWriter pw_log;
 
-  private static Time lastLogBackup;
-  private static final long BACKUP_RATE_IN_MS = 60000;
-
   /**
    * ArrayDeque is a double-ended, self-resizing queue, used
    * to keep track of commands for the transaction log and chat
@@ -52,7 +49,6 @@ public final class Chat {
   public Chat(Context context) {
 
     this.panels.push(createRootPanel(context));
-    lastLogBackup = Time.now();
 
     try {
       // Create a new transaction_log.txt file if needed - if not, this command does nothing
@@ -67,7 +63,7 @@ public final class Chat {
   }
 
   // Transfers all data in the Queue to write to the log
-  private void transferQueueToLog(){
+  public void transferQueueToLog(){
     while(!transactionLog.isEmpty()){
       pw_log.println(transactionLog.pop());
     }
@@ -93,15 +89,6 @@ public final class Chat {
     final String command = args.get(0);
     args.remove(0);
 
-    // Evaluate if it is time to transfer data from queue to disk, then call the transferQueueToLog() method defined
-    // above and update the last backup time
-    Time currentTime = Time.now();
-    if(currentTime.inMs() - lastLogBackup.inMs() >= BACKUP_RATE_IN_MS){
-      transferQueueToLog();
-      lastLogBackup = currentTime;
-    }
-
-
     // Because "exit" and "back" are applicable to every panel, handle
     // those commands here to avoid having to implement them for each
     // panel.
@@ -123,9 +110,6 @@ public final class Chat {
 
     if (panels.peek().handleCommand(command, args)) {
       // the command was handled
-
-      // Flush out buffer to ensure that every command gets written to file immediately
-      pw_log.flush();
       return true;
     }
 

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -14,6 +14,8 @@
 
 package codeu.chat.client.commandline;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.IOException;
 import java.util.*;
 
@@ -58,6 +60,38 @@ public final class Chat {
     } catch (IOException ex) {
       LOG.error(ex, "Failed to set logger to write to file");
     }
+
+    // Whenever a new Chat session is made, reload the data from the log
+    try {
+      reloadOldData();
+    } catch (Exception e){
+      System.out.println("Could not load transaction log.");
+    }
+
+  }
+
+  private void reloadOldData() throws IOException {
+    // Open the transaction log file for reading
+    FileReader fileReader = new FileReader("data/transaction_log.log");
+    BufferedReader bufferedReader = new BufferedReader(fileReader);
+
+    // Read the header of each log, as well as it's message
+    String headLine = bufferedReader.readLine();
+    String dataLine = bufferedReader.readLine();
+
+    // TODO: Parse the log data, and create users/conversations/messages as necessary
+    while(headLine != null && dataLine != null){
+
+      headLine = bufferedReader.readLine();
+      dataLine = bufferedReader.readLine();
+    }
+
+  }
+
+  // Transfers all data in the Queue to write to the log
+  private void transferQueueToLog(){
+    while(!transactionLog.isEmpty())
+      LOG.info(transactionLog.pop());
   }
 
   // HANDLE COMMAND
@@ -96,6 +130,9 @@ public final class Chat {
 
     if (panels.peek().handleCommand(command, args)) {
       // the command was handled
+
+      // TODO: Add an if statement evaluating if it is time to transfer data from queue to disk,
+      // then call the transferQueueToLog() method defined above
       return true;
     }
 

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -23,11 +23,10 @@ import codeu.chat.client.core.MessageContext;
 import codeu.chat.client.core.UserContext;
 import codeu.chat.common.*;
 import codeu.chat.util.Tokenizer;
-import codeu.chat.util.Time;
 
 public final class Chat {
 
-  private static final File logFile = new File("data/transaction_log.txt");
+  private static File logFile;
   private static PrintWriter pw_log;
 
   /**
@@ -46,20 +45,27 @@ public final class Chat {
   // panel all it needs to do is pop the top panel.
   private final Stack<Panel> panels = new Stack<>();
 
-  public Chat(Context context) {
+  public Chat(Context context){
 
     this.panels.push(createRootPanel(context));
+    logFile = new File("data/transaction_log.txt");
 
     try {
       // Create a new transaction_log.txt file if needed - if not, this command does nothing
       logFile.createNewFile();
 
       // Open the file as a PrintWriter and set file writing options to append
-      pw_log = new PrintWriter(new BufferedWriter(new FileWriter("data/transaction_log.txt", true)));
+      pw_log = new PrintWriter(new BufferedWriter(new FileWriter(logFile, true)));
     }
     catch (Exception ex){
       System.out.println("Unable to load transaction log.");
     }
+
+  }
+
+  public Chat(Context context, StringWriter stringWriter) {
+    this.panels.push(createRootPanel(context));
+    pw_log = new PrintWriter(stringWriter);
   }
 
   // Transfers all data in the Queue to write to the log
@@ -188,7 +194,6 @@ public final class Chat {
           if (user == null) {
             System.out.println("ERROR: Failed to create new user");
           } else {
-
             //command user-id username creation-time
             transactionLog.add(String.format("ADD-USER %s \"%s\" %s",
                     user.user.id,

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -75,18 +75,43 @@ public final class Chat {
     FileReader fileReader = new FileReader("data/transaction_log.log");
     BufferedReader bufferedReader = new BufferedReader(fileReader);
 
-    // Read the header of each log, as well as it's message
+    // Read the header lines of each transaction log
     String headLine = bufferedReader.readLine();
     String dataLine = bufferedReader.readLine();
 
     // TODO: Parse the log data, and create users/conversations/messages as necessary
     while(headLine != null && dataLine != null){
-      //holds default log String
+      //holds default log information line above each command
       headLine = bufferedReader.readLine();
       //holds what was inserted into log (what's parsed)
       dataLine = bufferedReader.readLine();
 
+      String[] logInfo = dataLine.split(" ");
+      //if the number of separate Strings in log isn't 6 or 7 it's not a command we logged
+      if (logInfo.length != 6 || logInfo.length != 7){
+        continue; //ignore this line, move on to parse next lines
+      }
 
+      //for all commands, name is the second element
+      String command = logInfo[1];
+      //UUid for the convo, user, or message depending on command type
+      String id = logInfo[2];
+      //for all commands, time and date are last and second-to-last elements
+      String time = logInfo[logInfo.length - 1];
+      String date = logInfo[logInfo.length - 2];
+
+      //if the log is for a user-related command (add/sign in) there will be 6 elements
+      if (logInfo.length == 6){
+        //for user-related commands 3rd element will be user's chosen name
+        String userName = logInfo[3];
+      }
+      //if the log is for a conversation or message command there will be 7 elements
+      else if (logInfo.length == 7){
+        //for convo/message commands 3rd element is creator's NUMERIC ID (UUID not name)
+        String ownerUUID = logInfo[3];
+        //for convo commands 4th element is convo name, for message commands 4th element is message content
+        String text = logInfo[4];
+      }
     }
 
   }
@@ -343,7 +368,7 @@ public final class Chat {
           } else {
             panels.push(createConversationPanel(conversation));
             transactionLog.add(String.format("ADD-CONVERSATION %s %s %s %s", conversation.conversation.id, conversation.conversation.owner,
-                    conversation.conversation.title, conversation.conversation.creation)); //command convo-id convo-owner convo-title creation-time
+                    conversation.conversation.title, conversation.conversation.creation)); //command convo-id (uuid of)convo-owner convo-title creation-time
             LOG.info(String.format("ADD-CONVERSATION %s %s %s %s", conversation.conversation.id, conversation.conversation.owner,
                     conversation.conversation.title, conversation.conversation.creation));
           }
@@ -369,7 +394,7 @@ public final class Chat {
           } else {
             panels.push(createConversationPanel(conversation));
             transactionLog.add(String.format("JOIN-CONVERSATION %s %s %s %s", conversation.conversation.id, conversation.conversation.owner,
-                    conversation.conversation.title, conversation.conversation.creation)); //command convo-id convo-owner convo-title creation-time
+                    conversation.conversation.title, conversation.conversation.creation)); //command convo-id (UUid of)convo-owner convo-title creation-time
             LOG.info(String.format("JOIN-CONVERSATION %s %s %s %s", conversation.conversation.id, conversation.conversation.owner,
                     conversation.conversation.title, conversation.conversation.creation));
           }

--- a/src/codeu/chat/client/core/Context.java
+++ b/src/codeu/chat/client/core/Context.java
@@ -24,7 +24,7 @@ import codeu.chat.common.User;
 import codeu.chat.util.Uuid;
 import codeu.chat.util.connections.ConnectionSource;
 
-public final class Context {
+public class Context {
 
   private final BasicView view;
   private final Controller controller;

--- a/src/codeu/chat/client/core/Context.java
+++ b/src/codeu/chat/client/core/Context.java
@@ -52,5 +52,4 @@ public final class Context {
   public ServerInfo getInfo() {
     return ((View)view).getInfo();
   }
-
 }

--- a/src/codeu/chat/client/core/Controller.java
+++ b/src/codeu/chat/client/core/Controller.java
@@ -29,7 +29,7 @@ import codeu.chat.util.Uuid;
 import codeu.chat.util.connections.Connection;
 import codeu.chat.util.connections.ConnectionSource;
 
-final class Controller implements BasicController {
+public class Controller implements BasicController {
 
   private final static Logger.Log LOG = Logger.newLog(Controller.class);
 

--- a/src/codeu/chat/client/core/View.java
+++ b/src/codeu/chat/client/core/View.java
@@ -137,8 +137,12 @@ final class View implements BasicView {
     try (final Connection connection = this.source.connect()) {
       Serializers.INTEGER.write(connection.out(), NetworkCode.SERVER_INFO_REQUEST);
 
-      if (Serializers.INTEGER.read(connection.in()) == NetworkCode.SERVER_INFO_RESPONSE)
-        return new ServerInfo(Uuid.SERIALIZER.read(connection.in()));
+      if (Serializers.INTEGER.read(connection.in()) == NetworkCode.SERVER_INFO_RESPONSE) {
+        final Uuid version = Uuid.SERIALIZER.read(connection.in());
+        final Time startTime = Time.SERIALIZER.read(connection.in());
+
+        return new ServerInfo(version, startTime);
+      }
       else {
         // Communicate this error - the server did not respond with the type of
         // response we expected.
@@ -150,26 +154,6 @@ final class View implements BasicView {
     }
     // If we get here it means something went wrong and null should be returned
     return null;
-  }
-  
-  public ServerInfo getInfo() {
-    try (final Connection connection = source.connection()) {
-      Serializers.INTEGER.write(connection.out(), NetworkCode.SERVER_INFO_REQUEST);
-      if (Serializers.INTEGER.read(connection.in()) == NetworkCode.SERVER_INFO_RESPONSE) {
-        final Time startTime = Time.SERIALIZER.read(connection.in());
-        return new ServerInfo(startTime);
-      } else {
-         // Communicate this error - the server did not respond with the type of
-         // response we expected
-        throw new IllegalArgumentException("The server did not respond with what we expected.");
-      } catch (IllegalArgumentException ex) {
-         // Communicate this error - something went wrong with the connection.
-      }
-      return null;
-    }
-        
- }
-
   }
 
 }

--- a/src/codeu/chat/client/core/View.java
+++ b/src/codeu/chat/client/core/View.java
@@ -30,7 +30,7 @@ import codeu.chat.util.connections.ConnectionSource;
 // This is the view component of the Model-View-Controller pattern used by the
 // the client to retrieve readonly data from the server. All methods are blocking
 // calls.
-final class View implements BasicView {
+public class View implements BasicView {
 
   private final static Logger.Log LOG = Logger.newLog(View.class);
 

--- a/src/codeu/chat/common/ServerInfo.java
+++ b/src/codeu/chat/common/ServerInfo.java
@@ -33,9 +33,22 @@ public final class ServerInfo {
   
     public ServerInfo(Time startTime) {
        this.startTime = startTime;
+
+        try {
+            this.version = Uuid.parse(SERVER_VERSION);
+        } catch(Exception ex) {
+            this.version = Uuid.NULL;
+            LOG.error(ex, "Server version cannot be parsed. Default Uuid version used.");
+        }
     }
 
     public ServerInfo(Uuid version) {
         this.version = version;
+        this.startTime = Time.now();
+    }
+
+    public ServerInfo(Uuid version, Time startTime){
+        this.version = version;
+        this.startTime = startTime;
     }
 }

--- a/src/codeu/chat/server/Server.java
+++ b/src/codeu/chat/server/Server.java
@@ -258,6 +258,8 @@ public final class Server {
       line = bufferedReader.readLine();
     }
 
+    LOG.info("Successfully restored last logged server state.");
+
     fileReader.close();
     bufferedReader.close();
   }

--- a/src/codeu/chat/server/Server.java
+++ b/src/codeu/chat/server/Server.java
@@ -220,7 +220,6 @@ public final class Server {
             command.onMessage(connection.in(), connection.out());
             LOG.info("Connection accepted");
           }
-
         } catch (Exception ex) {
 
           LOG.error(ex, "Exception while handling connection.");

--- a/src/codeu/chat/server/Server.java
+++ b/src/codeu/chat/server/Server.java
@@ -15,9 +15,7 @@
 
 package codeu.chat.server;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.Arrays;
@@ -25,6 +23,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import codeu.chat.client.core.Context;
 import codeu.chat.common.*;
 import codeu.chat.util.Logger;
 import codeu.chat.util.Serializers;
@@ -65,6 +64,13 @@ public final class Server {
     this.secret = secret;
     this.controller = new Controller(id, model);
     this.relay = relay;
+
+    // Whenever a new Chat session is made, reload the data from the log
+    try {
+      reloadOldData();
+    } catch (Exception e){
+      System.out.println("Could not load transaction log.");
+    }
 
     // New Message - A client wants to add a new message to the back end.
     this.commands.put(NetworkCode.NEW_MESSAGE_REQUEST, new Command() {
@@ -199,6 +205,76 @@ public final class Server {
         timeline.scheduleIn(RELAY_REFRESH_MS, this);
       }
     });
+  }
+
+  private void reloadOldData() throws IOException {
+    // Open the transaction log file for reading
+    FileReader fileReader = new FileReader("data/transaction_log.txt");
+    BufferedReader bufferedReader = new BufferedReader(fileReader);
+
+    // Read the header lines of each transaction log
+    String line = bufferedReader.readLine();
+
+    while(line != null) {
+      String[] logInfo = line.split(" ");
+
+      // Three pieces of data applicable to all log elements: it's command type, Uuid, and Time in milliseconds
+      String commandType = logInfo[0];
+      Uuid commandUuid = Uuid.parse(logInfo[1]);
+      Time commandCreation = Time.fromMs(Long.parseLong(logInfo[logInfo.length - 1]));
+
+      // USER reload
+      if (commandType.equals("ADD-USER")) {
+        int i = 2;
+        // For user-related commands 3rd element will be user's chosen name
+        String userName = logInfo[i];
+
+        // Keep appending username data until reaching a terminal end quote
+        while(i < logInfo.length && !userName.substring(userName.length() - 1).equals("\""))
+          userName += " " + logInfo[++i];
+
+        // Create a new user based on it's unique contents, as well as it's username without quotes
+        controller.newUser(commandUuid, userName.substring(1, userName.length() - 1), commandCreation);
+      }
+
+      // CONVERSATION reload
+      else if (commandType.equals("ADD-CONVERSATION")) {
+        // For convo/message commands 3rd element is creator's NUMERIC ID (UUID not name)
+        Uuid ownerUuid = Uuid.parse(logInfo[2]);
+
+        int i = 3;
+        // For convo commands 4th element is convo name, for message commands 4th element is message content
+        String convoTitle = logInfo[i];
+
+        // Keep appending conversation title data until reaching a terminal end quote
+        while(i < logInfo.length && !convoTitle.substring(convoTitle.length() - 1).equals("\""))
+          convoTitle += " " + logInfo[++i];
+
+        controller.newConversation(commandUuid, convoTitle.substring(1, convoTitle.length() - 1), ownerUuid, commandCreation);
+      }
+
+      // MESSAGE reload
+      else if (commandType.equals("ADD-MESSAGE")) {
+        // For convo/message commands 3rd element is creator's NUMERIC ID (UUID not name)
+        Uuid ownerUuid = Uuid.parse(logInfo[2]);
+        Uuid convoUuid = Uuid.parse(logInfo[3]);
+
+        int i = 4;
+        // For convo commands 5th element is convo name, for message commands 4th element is message content
+        String messageContent = logInfo[i];
+
+        // Keep appending message data until reaching a terminal end quote
+        while(i < logInfo.length && !messageContent.substring(messageContent.length() - 1).equals("\""))
+          messageContent += " " + logInfo[++i];
+
+        controller.newMessage(commandUuid, ownerUuid, convoUuid, messageContent.substring(1, messageContent.length() - 1), commandCreation);
+      }
+
+      line = bufferedReader.readLine();
+    }
+
+    fileReader.close();
+    bufferedReader.close();
   }
 
   public void handleConnection(final Connection connection) {

--- a/src/codeu/chat/util/Tokenizer.java
+++ b/src/codeu/chat/util/Tokenizer.java
@@ -7,6 +7,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.Function;
 
+//comment to test the first commit to the persistent_storage branch
 public final class  Tokenizer implements Iterator<String> {
 
     //stores the final "token" form of the input

--- a/src/codeu/chat/util/Tokenizer.java
+++ b/src/codeu/chat/util/Tokenizer.java
@@ -5,7 +5,6 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.Function;
 
-//comment to test the first commit to the persistent_storage branch
 public final class  Tokenizer implements Iterator<String> {
 
     //stores the final "token" form of the input

--- a/src/codeu/chat/util/Tokenizer.java
+++ b/src/codeu/chat/util/Tokenizer.java
@@ -1,7 +1,5 @@
 package codeu.chat.util;
 
-import com.sun.xml.internal.ws.policy.privateutil.PolicyUtils;
-
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;

--- a/test/codeu/chat/TestRunner.java
+++ b/test/codeu/chat/TestRunner.java
@@ -30,7 +30,8 @@ public final class TestRunner {
              codeu.chat.util.TimeTest.class,
              codeu.chat.util.UuidTest.class,
              codeu.chat.util.store.StoreTest.class,
-             codeu.chat.util.TokenizerTest.class
+             codeu.chat.util.TokenizerTest.class,
+             codeu.chat.client.commandline.ChatTest.class
          );
       for (final Failure failure : result.getFailures()) {
          System.out.println(failure.toString());

--- a/test/codeu/chat/client/commandline/ChatTest.java
+++ b/test/codeu/chat/client/commandline/ChatTest.java
@@ -1,0 +1,65 @@
+package codeu.chat.client.commandline;
+
+import static org.junit.Assert.*;
+import codeu.chat.client.core.Context;
+import codeu.chat.util.RemoteAddress;
+import codeu.chat.util.connections.ClientConnectionSource;
+import codeu.chat.util.connections.Connection;
+import codeu.chat.util.connections.ConnectionSource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.*;
+import java.net.Socket;
+import java.nio.Buffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by dita on 6/17/17.
+ */
+public final class ChatTest {
+
+    private Chat chat;
+    private ConnectionSource connectionSource;
+
+    private BufferedReader bufferedReader;
+
+    @Before
+    public void doBefore() throws IOException{
+        String hostName = "localhost";
+        int portNumber = 1025;
+
+        connectionSource = new ClientConnectionSource(hostName, portNumber);
+        connectionSource.connect();
+        chat = new Chat(new Context(connectionSource));
+
+        bufferedReader = new BufferedReader(new FileReader(new File("data/transaction_log.txt")));
+    }
+
+    @Test
+    public void addUserTest() throws Exception {
+        boolean addUser = chat.handleCommand("u-add username");
+        assertTrue(addUser);
+        TimeUnit.MINUTES.wait(1);
+        assertNotNull(bufferedReader.readLine());
+    }
+
+    @Test
+    public void addConvoTest() throws Exception {
+        chat.handleCommand("u-sign-in username");
+        boolean addConvo = chat.handleCommand("c-add convo");
+        assertTrue(addConvo);
+        TimeUnit.MINUTES.wait(1);
+        assertNotNull(bufferedReader.readLine());
+    }
+
+    @Test
+    public void addMessageTest() throws Exception {
+        boolean addMessage = chat.handleCommand("m-add message");
+        assertTrue(addMessage);
+        TimeUnit.MINUTES.wait(1);
+        assertNotNull(bufferedReader.readLine());
+    }
+}

--- a/test/codeu/chat/client/commandline/ChatTest.java
+++ b/test/codeu/chat/client/commandline/ChatTest.java
@@ -1,19 +1,21 @@
 package codeu.chat.client.commandline;
 
 import static org.junit.Assert.*;
-import codeu.chat.client.core.Context;
-import codeu.chat.util.RemoteAddress;
+
+import codeu.chat.client.core.*;
+import codeu.chat.common.*;
+import codeu.chat.util.Time;
+import codeu.chat.util.Uuid;
 import codeu.chat.util.connections.ClientConnectionSource;
-import codeu.chat.util.connections.Connection;
-import codeu.chat.util.connections.ConnectionSource;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runners.model.TestClass;
 
 import java.io.*;
-import java.net.Socket;
-import java.nio.Buffer;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -21,45 +23,149 @@ import java.util.concurrent.TimeUnit;
  */
 public final class ChatTest {
 
-    private Chat chat;
-    private ConnectionSource connectionSource;
+    private ServerInfo serverInfo;
+    private User user;
+    private UserContext userContext;
+    private ConversationHeader convo;
+    private ConversationContext convoContext;
+    private Message message;
+    private MessageContext messageContext;
 
-    private BufferedReader bufferedReader;
+    private TemporaryFolder folder = new TemporaryFolder();
+
+    private class TestController extends Controller {
+
+        public TestController(){
+            super(new ClientConnectionSource("localhost", 1025));
+        }
+
+        @Override
+        public Message newMessage(Uuid author, Uuid conversation, String body) {
+            return message;
+        }
+
+        @Override
+        public User newUser(String name) {
+            return user;
+        }
+
+        @Override
+        public ConversationHeader newConversation(String title, Uuid owner) {
+            return convo;
+        }
+    }
+
+    private class TestView extends codeu.chat.client.core.View {
+
+        public TestView() {
+            super(new ClientConnectionSource("localhost", 1025));
+        }
+
+        @Override
+        public Collection<User> getUsers() {
+            Collection<User> users = new ArrayList<>();
+            users.add(user);
+
+            return users;
+        }
+
+        @Override
+        public Collection<ConversationHeader> getConversations() {
+            Collection<ConversationHeader> conversations = new ArrayList<>();
+            conversations.add(convo);
+
+            return conversations;
+        }
+
+        @Override
+        public Collection<ConversationPayload> getConversationPayloads(Collection<Uuid> ids) {
+            return super.getConversationPayloads(ids);
+        }
+
+        @Override
+        public Collection<Message> getMessages(Collection<Uuid> ids) {
+            Collection<Message> messages = new ArrayList<>();
+            messages.add(message);
+
+            return messages;
+        }
+
+        @Override
+        public ServerInfo getInfo() {
+            return serverInfo;
+        }
+    }
+
+    private class TestContext extends Context{
+
+        private final UserContext userContext = new UserContext(user, new TestView(), new TestController());
+        private final TestView view;
+        private final TestController controller;
+
+        public TestContext(TestView view, TestController controller) {
+            super(new ClientConnectionSource("localhost", 1025));
+
+            this.view = view;
+            this.controller = controller;
+        }
+
+        @Override
+        public UserContext create(String name) {
+            return userContext;
+        }
+
+        @Override
+        public Iterable<UserContext> allUsers() {
+            final Collection<UserContext> users = new ArrayList<>();
+            users.add(userContext);
+
+            return users;
+        }
+
+        @Override
+        public ServerInfo getInfo() {
+            return serverInfo;
+        }
+    }
+
+    private Chat chat;
 
     @Before
     public void doBefore() throws IOException{
-        String hostName = "localhost";
-        int portNumber = 1025;
+        TestView view = new TestView();
+        TestController controller = new TestController();
 
-        connectionSource = new ClientConnectionSource(hostName, portNumber);
-        connectionSource.connect();
-        chat = new Chat(new Context(connectionSource));
+        serverInfo = new ServerInfo();
+        user = new User(Uuid.NULL, "username", Time.now());
+        convo = new ConversationHeader(Uuid.NULL, Uuid.NULL, Time.now(), "convo");
+        message = new Message(Uuid.NULL, Uuid.NULL, Uuid.NULL, Time.now(), Uuid.NULL, "message");
 
-        bufferedReader = new BufferedReader(new FileReader(new File("data/transaction_log.txt")));
+        userContext = new UserContext(user, view, controller);
+        convoContext = new ConversationContext(user, convo, view, controller);
+        messageContext = new MessageContext(message, view);
+
+        chat = new Chat(new TestContext(view, controller));
     }
 
     @Test
     public void addUserTest() throws Exception {
-        boolean addUser = chat.handleCommand("u-add username");
-        assertTrue(addUser);
-        TimeUnit.MINUTES.wait(1);
-        assertNotNull(bufferedReader.readLine());
+        boolean addUser = chat.handleCommand("u-sign-in username");
+        assertEquals(true, addUser);
     }
 
     @Test
     public void addConvoTest() throws Exception {
         chat.handleCommand("u-sign-in username");
-        boolean addConvo = chat.handleCommand("c-add convo");
-        assertTrue(addConvo);
-        TimeUnit.MINUTES.wait(1);
-        assertNotNull(bufferedReader.readLine());
+
+        boolean addConvo = chat.handleCommand("c-join convo");
+        assertEquals(true, addConvo);
     }
 
     @Test
     public void addMessageTest() throws Exception {
+        chat.handleCommand("u-sign-in username");
+        chat.handleCommand("c-join convo");
         boolean addMessage = chat.handleCommand("m-add message");
-        assertTrue(addMessage);
-        TimeUnit.MINUTES.wait(1);
-        assertNotNull(bufferedReader.readLine());
+        assertEquals(true, addMessage);
     }
 }

--- a/test/codeu/chat/common/ServerInfoTest.java
+++ b/test/codeu/chat/common/ServerInfoTest.java
@@ -1,7 +1,6 @@
 package codeu.chat.common;
 
 import static org.junit.Assert.*;
-
 import java.io.IOException;
 
 import codeu.chat.util.Uuid;


### PR DESCRIPTION
Added feature to retain chat data after server shutdown by recording important user commands (`u-add`, `c-add`, and `m-add`) to a transaction log.
Recorded commands are formatted as strings and pushed to a queue, which eventually empties out to a `transaction_log.txt`. Data from queue is written to disk every 60 seconds.

Code ensures data is written to the text file immediately by flushing out the `PrintWriter` buffer every time the data is transferred.

Important user commands are formatted like so, with the time written in milliseconds:
`ADD-USER <user_id> "<user_name>" <user_time>`
`ADD-CONVERSATION <convo_id> "<convo_owner_id>" <convo_title> <convo_time>`
`ADD-MESSAGE <message_id> <message_author_id> <convo_id> "<message_content>" <message_time>`

In `Chat.java`: `transaction_log.txt` is opened (and created if it doesn't exist), and corresponding commands are pushed to queue every time they are called. The time is evaluated during every user activity to check if 60 seconds has passed, and `lastLogBackup` time is updated and queue data transfers to `transaction_log.txt` if so. 

In `Server.java`: The `reloadOldData()` method is called when a new `Server` is created, and `transaction_log.txt` data is parsed and re-made with their original object data.

😺