### PR TITLE
Interest System

### DIFF
--- a/src/codeu/chat/ClientMain.java
+++ b/src/codeu/chat/ClientMain.java
@@ -99,6 +99,7 @@ final class ClientMain {
     final ConnectionSource source = new ClientConnectionSource(address.host, address.port);
 
     LOG.info("Creating client...");
+
     chat = new Chat(new Context(source));
 
     LOG.info("Created client");

--- a/src/codeu/chat/ClientMain.java
+++ b/src/codeu/chat/ClientMain.java
@@ -78,6 +78,8 @@ final class ClientMain {
 
     LOG.info("Successfully restored last logged interest system state.");
 
+    System.out.println("Successfully loaded interest system!");
+
     fileReader.close();
     bufferedReader.close();
   }

--- a/src/codeu/chat/ClientMain.java
+++ b/src/codeu/chat/ClientMain.java
@@ -14,16 +14,11 @@
 
 package codeu.chat;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.*;
 
 import codeu.chat.client.commandline.Chat;
 import codeu.chat.client.core.Context;
-import codeu.chat.util.Logger;
-import codeu.chat.util.RemoteAddress;
-import codeu.chat.util.Time;
+import codeu.chat.util.*;
 import codeu.chat.util.connections.ClientConnectionSource;
 import codeu.chat.util.connections.ConnectionSource;
 
@@ -33,6 +28,59 @@ final class ClientMain {
 
   private static Time lastLogBackup;
   private static final long BACKUP_RATE_IN_MS = 30000;
+
+  private static Chat chat;
+
+  private static void reloadOldInterests() throws IOException {
+    // Open the transaction log file for reading
+    FileReader fileReader = new FileReader("data/transaction_log.txt");
+    BufferedReader bufferedReader = new BufferedReader(fileReader);
+
+    // Read the header lines of each transaction log
+    String line = bufferedReader.readLine();
+
+    System.out.println("Loading interest system...");
+
+    while(line != null) {
+
+      // Instantiate a Tokenizer to parse through log's data
+      Tokenizer logInfo = new Tokenizer(line);
+
+      String commandType = logInfo.next();
+
+      if(commandType.equals("ADD-INTEREST-USER")){
+        Uuid owner = Uuid.parse(logInfo.next());
+        Uuid follow = Uuid.parse(logInfo.next());
+
+        chat.addUserInterest(owner, follow);
+      }
+      else if(commandType.equals("REMOVE-INTEREST-USER")){
+        Uuid owner = Uuid.parse(logInfo.next());
+        Uuid follow = Uuid.parse(logInfo.next());
+
+        chat.removeUserInterest(owner, follow);
+      }
+      else if(commandType.equals("ADD-INTEREST-CONVERSATION")){
+        Uuid owner = Uuid.parse(logInfo.next());
+        Uuid follow = Uuid.parse(logInfo.next());
+
+        chat.addConvoInterest(owner, follow);
+      }
+      else if(commandType.equals("REMOVE-INTEREST-CONVERSATION")){
+        Uuid owner = Uuid.parse(logInfo.next());
+        Uuid follow = Uuid.parse(logInfo.next());
+
+        chat.removeConvoInterest(owner, follow);
+      }
+
+      line = bufferedReader.readLine();
+    }
+
+    LOG.info("Successfully restored last logged interest system state.");
+
+    fileReader.close();
+    bufferedReader.close();
+  }
 
   public static void main(String [] args) {
 
@@ -51,9 +99,16 @@ final class ClientMain {
     final ConnectionSource source = new ClientConnectionSource(address.host, address.port);
 
     LOG.info("Creating client...");
-    final Chat chat = new Chat(new Context(source));
+    chat = new Chat(new Context(source));
 
     LOG.info("Created client");
+
+    // Reload old interests
+    try {
+      reloadOldInterests();
+    } catch (Exception e) {
+      LOG.info("Could not reload last logged interest system.");
+    }
 
     boolean keepRunning = true;
 

--- a/src/codeu/chat/ClientMain.java
+++ b/src/codeu/chat/ClientMain.java
@@ -33,15 +33,14 @@ final class ClientMain {
 
   private static void reloadOldInterests() throws IOException {
     // Open the transaction log file for reading
-    FileReader fileReader = new FileReader("data/transaction_log.txt");
-    BufferedReader bufferedReader = new BufferedReader(fileReader);
+    BufferedReader bufferedReader = new BufferedReader(new FileReader("data/transaction_log.txt"));
 
     // Read the header lines of each transaction log
-    String line = bufferedReader.readLine();
+    String line;
 
     System.out.println("Loading interest system...");
 
-    while(line != null) {
+    while((line = bufferedReader.readLine()) != null) {
 
       // Instantiate a Tokenizer to parse through log's data
       Tokenizer logInfo = new Tokenizer(line);
@@ -80,7 +79,6 @@ final class ClientMain {
 
     System.out.println("Successfully loaded interest system!");
 
-    fileReader.close();
     bufferedReader.close();
   }
 

--- a/src/codeu/chat/ClientMain.java
+++ b/src/codeu/chat/ClientMain.java
@@ -71,8 +71,6 @@ final class ClientMain {
 
         chat.removeConvoInterest(owner, follow);
       }
-
-      line = bufferedReader.readLine();
     }
 
     LOG.info("Successfully restored last logged interest system state.");

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -239,6 +239,8 @@ public final class Chat {
           if (user == null) {
             System.out.format("ERROR: Failed to sign in as '%s'\n", name);
           } else {
+              Set<Uuid> updatedConversations = new HashSet<>();
+            updatedConversationsMap.put(user.user.id, updatedConversations);
             panels.push(createUserPanel(user));
           }
         } else {
@@ -638,8 +640,8 @@ public final class Chat {
             // Iterate through the followed user's conversations and check if they have updated any conversations
             for (ConversationContext updatedConvoID : followedUser.conversations()) {
               // If the followed user's updated conversations map has the convo print out info
-              if (updatedConversationsMap.get(userID).contains(updatedConvoID))
-                System.out.format("\t\tUpdated: %s\n", updatedConvoID.conversation.title);
+              if (updatedConversationsMap.containsKey(userID) && updatedConversationsMap.get(userID).contains(updatedConvoID))
+                  System.out.format("\t\tUpdated: %s\n", updatedConvoID.conversation.title);
             }
           }
         }
@@ -742,7 +744,7 @@ public final class Chat {
           MessageContext messageContext = conversation.add(message);
 
           //if this user isn't in the updated conversations map, add them with a new Set
-          Set<Uuid> updatedConversations = new HashSet<>();
+          Set<Uuid> updatedConversations;
           if (!updatedConversationsMap.containsKey(userPanelContext.user.id)){
             updatedConversations = new HashSet<>();
           }

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -321,7 +321,7 @@ public final class Chat {
     panel.register("c-list", new Panel.Command() {
       @Override
       public void invoke(List<String> args) {
-        for (final ConversationContext conversation : user.conversations()) {
+        for (final ConversationContext conversation : user.conversations().values()) {
           System.out.format(
               "CONVERSATION %s (UUID: %s)\n",
               conversation.conversation.title,
@@ -387,7 +387,7 @@ public final class Chat {
       // Find the first conversation with the given name and return its context.
       // If no conversation has the given name, this will return null.
       private ConversationContext find(String title) {
-        for (final ConversationContext conversation : user.conversations()) {
+        for (final ConversationContext conversation : user.conversations().values()) {
           if (title.equals(conversation.conversation.title)) {
             return conversation;
           }
@@ -448,7 +448,7 @@ public final class Chat {
       // Find the first conversation with the given name and return its context.
       // If no conversation has the given name, this will return null.
       private ConversationContext findConversation(String title) {
-        for (final ConversationContext conversation : user.conversations()) {
+        for (final ConversationContext conversation : user.conversations().values()) {
           if (title.equals(conversation.conversation.title)) {
             return conversation;
           }
@@ -589,7 +589,7 @@ public final class Chat {
             System.out.format("\t%s has added and updated these conversations:\n", followedUser.user.name);
 
             // Iterate through all the conversations this user has and check if they created/updated any
-            for(ConversationContext followedUserConversation : followedUser.conversations()) {
+            for(ConversationContext followedUserConversation : followedUser.conversations().values()) {
               // If the newConversationsMap has this followed user and this specific conversation, print that they created it
               if (newConversationsMap.get(followedUserID) != null && newConversationsMap.get(followedUserID).contains(followedUserConversation.conversation.id)) {
                 System.out.format("\t\tCreated: %s (UUID: %s)\n", followedUserConversation.conversation.title, followedUserConversation.conversation.id);
@@ -820,7 +820,7 @@ public final class Chat {
   // Find the first conversation with the given name and return its context.
   // If no conversation has the given name, this will return null.
   private ConversationContext findConversation(String title) {
-    for (final ConversationContext conversation : userPanelContext.conversations()) {
+    for (final ConversationContext conversation : userPanelContext.conversations().values()) {
       if (title.equals(conversation.conversation.title)) {
         return conversation;
       }
@@ -831,12 +831,7 @@ public final class Chat {
   // Finds the first conversation with the given name and returns its context.
   // If no conversation has the given name, this will return null.
   private ConversationContext findConversation(Uuid id) {
-    for (final ConversationContext conversation : userPanelContext.conversations()) {
-      if (id.equals(conversation.conversation.id)) {
-        return conversation;
-      }
-     }
-    return null;
+    return userPanelContext.conversations().get(id);
    }
 
   public void addUserInterest(Uuid userID, Uuid followedUserID){
@@ -851,10 +846,10 @@ public final class Chat {
     if(userInterest.contains(followedUserID))
       System.out.println("ERROR: User is already followed!");
     else {
-      HashMap<Uuid, Integer> followedUserConversations = (convoMessageCountsMap.get(followedUserID) == null) ? new HashMap<>() : convoMessageCountsMap.get(followedUserID);
+      HashMap<Uuid, Integer> followedUserConversations = convoMessageCountsMap.computeIfAbsent(followedUserID, messageCount -> new HashMap<>());
 
       // Intialize the message count for all of this users conversations to 0
-      for(ConversationContext c : findUser(followedUserID).conversations()){
+      for(ConversationContext c : findUser(followedUserID).conversations().values()){
         followedUserConversations.put(c.conversation.id, 0);
       }
 
@@ -866,7 +861,7 @@ public final class Chat {
   }
 
   public void addConvoInterest(Uuid userID, Uuid followedConvoID){
-    Set<Uuid> convoInterest = (convoInterestMap.get(userID) == null) ? new HashSet<>() : convoInterestMap.get(userID);
+    Set<Uuid> convoInterest = convoInterestMap.computeIfAbsent(userID, followedConvo -> new HashSet<>());
 
     if(convoInterest.contains(followedConvoID))
         System.out.println("ERROR: Conversation is already in interest list!");
@@ -874,7 +869,7 @@ public final class Chat {
       convoInterest.add(followedConvoID);
       convoInterestMap.put(userID, convoInterest);
 
-      HashMap<Uuid, Integer> followedConversations = (convoMessageCountsMap.get(userID) == null) ? new HashMap<>() : convoMessageCountsMap.get(userID);
+      HashMap<Uuid, Integer> followedConversations = convoMessageCountsMap.computeIfAbsent(userID, messageCount -> new HashMap<>());
       followedConversations.put(followedConvoID, 0);
     }
   }

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -412,7 +412,7 @@ public final class Chat {
             System.out.format("ERROR: No conversation with name '%s'\n", name);
           } else {
             //add specified conversation to user's interests
-            user.user.interests.add(conversation.conversation.id);
+            user.user.convoInterests.add(conversation.conversation.id);
           }
         } else {
           System.out.println("ERROR: Missing <title>");
@@ -446,7 +446,7 @@ public final class Chat {
             System.out.format("ERROR: No conversation with name '%s'\n", name);
           } else {
             //if conversation is in interests it's removed, if not nothing is done
-            user.user.interests.remove(conversation.conversation.id);
+            user.user.convoInterests.remove(conversation.conversation.id);
           }
         } else {
           System.out.println("ERROR: Missing <title>");
@@ -480,7 +480,7 @@ public final class Chat {
             System.out.format("ERROR: User '%s' does not exist.\n", name);
           } else {
             //adding specified user's Uuid to current user's interests
-            user.user.interests.add(interestUser.user.id);
+            user.user.userInterests.add(interestUser.user.id);
           }
         } else {
           System.out.println("ERROR: Missing <username>");
@@ -514,7 +514,7 @@ public final class Chat {
             System.out.format("ERROR: User '%s' does not exist.\n", name);
           } else {
             //removing specified user from current user's interests
-            user.user.interests.remove(interestUser.user.id);
+            user.user.userInterests.remove(interestUser.user.id);
           }
         } else {
           System.out.println("ERROR: Missing <username>");

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -33,6 +33,9 @@ public final class Chat {
   private static Time lastLogBackup;
   private static final long BACKUP_RATE_IN_MS = 60000;
 
+  //used to access Chat's users from the user panel for interest system feature
+  private Context rootPanelContext;
+
   /**
    * ArrayDeque is a double-ended, self-resizing queue, used
    * to keep track of commands for the transaction log and chat
@@ -151,6 +154,7 @@ public final class Chat {
   private Panel createRootPanel(final Context context) {
 
     final Panel panel = new Panel();
+    rootPanelContext = context;
 
     // HELP
     //
@@ -294,6 +298,16 @@ public final class Chat {
         System.out.println("    Add a new conversation with the given title and join it as the current user.");
         System.out.println("  c-join <title>");
         System.out.println("    Join the conversation as the current user.");
+        System.out.println("  c-interest add <title>");
+        System.out.println("    Adds the specified conversation to user's interests.");
+        System.out.println("  c-interest remove <title>");
+        System.out.println("    Removes the specified conversation from the user's interests.");
+        System.out.println("  u-interest add <username>");
+        System.out.println("    Adds the specified user to user's interests.");
+        System.out.println("  u-interest remove <username>");
+        System.out.println("    Removes the specified user from the user's interests.");
+        System.out.println("  status update");
+        System.out.println("    Lists what interests have been updated.");
         System.out.println("  info");
         System.out.println("    Display all info for the current user");
         System.out.println("  back");
@@ -380,6 +394,164 @@ public final class Chat {
           }
         }
         return null;
+      }
+    });
+
+    //C-INTEREST ADD (adds conversation to user's interests)
+    //
+    //"c-interest add <conversation title>" will allow user to add specified
+    //conversation to interests and receive status updates on conversation
+    //
+    panel.register("c-interest add", new Panel.Command() {
+      @Override
+      public void invoke(List<String> args){
+        final String name = args.size() > 0 ? String.join(" ", args.subList(0, args.size())) : "";
+        if (name.length() > 0) {
+          final ConversationContext conversation = findConversation(name);
+          if (conversation == null) {
+            System.out.format("ERROR: No conversation with name '%s'\n", name);
+          } else {
+            //add specified conversation to user's interests
+            user.user.interests.add(conversation.conversation.id);
+          }
+        } else {
+          System.out.println("ERROR: Missing <title>");
+        }
+      }
+
+      // Find the first conversation with the given name and return its context.
+      // If no conversation has the given name, this will return null.
+      private ConversationContext findConversation(String title) {
+        for (final ConversationContext conversation : user.conversations()) {
+          if (title.equals(conversation.conversation.title)) {
+            return conversation;
+          }
+        }
+        return null;
+      }
+    });
+
+    //C-INTEREST REMOVES (removes conversation to user's interests)
+    //
+    //"c-interest add <conversation title>" will allow user to remove specified
+    //conversation from interests and stop receiving status updates on conversation
+    //
+    panel.register("c-interest remove", new Panel.Command() {
+      @Override
+      public void invoke(List<String> args){
+        final String name = args.size() > 0 ? String.join(" ", args.subList(0, args.size())) : "";
+        if (name.length() > 0) {
+          final ConversationContext conversation = findConversation(name);
+          if (conversation == null) {
+            System.out.format("ERROR: No conversation with name '%s'\n", name);
+          } else {
+            //if conversation is in interests it's removed, if not nothing is done
+            user.user.interests.remove(conversation.conversation.id);
+          }
+        } else {
+          System.out.println("ERROR: Missing <title>");
+        }
+      }
+
+      // Find the first conversation with the given name and return its context.
+      // If no conversation has the given name, this will return null.
+      private ConversationContext findConversation(String title) {
+        for (final ConversationContext conversation : user.conversations()) {
+          if (title.equals(conversation.conversation.title)) {
+            return conversation;
+          }
+        }
+        return null;
+      }
+    });
+
+    //U-INTEREST ADD (adds user to user's interests)
+    //
+    //"u-interest add <username>" will allow user to add specified
+    //user to interests and receive status updates on conversation.
+    //
+    panel.register("u-interest add", new Panel.Command() {
+      @Override
+      public void invoke(List<String> args) {
+        final String name = args.size() > 0 ? String.join(" ", args.subList(0, args.size())) : "";
+        if (name.length() > 0) {
+          final UserContext interestUser = findUser(name);
+          if (user == null) {
+            System.out.format("ERROR: User '%s' does not exist.\n", name);
+          } else {
+            //adding specified user's Uuid to current user's interests
+            user.user.interests.add(interestUser.user.id);
+          }
+        } else {
+          System.out.println("ERROR: Missing <username>");
+        }
+      }
+
+      // Find the first user with the given name and return a user context
+      // for that user. If no user is found, the function will return null.
+      private UserContext findUser(String name) {
+        for (final UserContext user : rootPanelContext.allUsers()) {
+          if (user.user.name.equals(name)) {
+            return user;
+          }
+        }
+        return null;
+      }
+    });
+
+    //U-INTEREST REMOVE (removes user from user's interests)
+    //
+    //"u-interest remove <username>" will allow user to remove specified
+    //user from interests and stop receiving status updates on conversation.
+    //
+    panel.register("u-interest remove", new Panel.Command() {
+      @Override
+      public void invoke(List<String> args) {
+        final String name = args.size() > 0 ? String.join(" ", args.subList(0, args.size())) : "";
+        if (name.length() > 0) {
+          final UserContext interestUser = findUser(name);
+          if (user == null) {
+            System.out.format("ERROR: User '%s' does not exist.\n", name);
+          } else {
+            //removing specified user from current user's interests
+            user.user.interests.remove(interestUser.user.id);
+          }
+        } else {
+          System.out.println("ERROR: Missing <username>");
+        }
+      }
+
+      // Find the first user with the given name and return a user context
+      // for that user. If no user is found, the function will return null.
+      private UserContext findUser(String name) {
+        for (final UserContext user : rootPanelContext.allUsers()) {
+          if (user.user.name.equals(name)) {
+            return user;
+          }
+        }
+        return null;
+      }
+    });
+
+    //TODO status update command
+    // STATUS UPDATE
+    //
+    // Command that prints info about the user's interests when
+    // user enters "status update" while on user panel.
+    //
+    // For users of interest, prints what conversations they've created and
+    // what conversations they've messaged to since the last update.
+    // For conversations of interest, prints how many messages have been
+    // created since last update.
+    //
+    panel.register("status update", new Panel.Command() {
+      @Override
+      public void invoke(List<String> args) {
+        System.out.println("Followed Users:");
+        //every user Uuid in interests Set should be printed with all their info
+
+        System.out.println("Followed Conversations:");
+        //every conversation Uuid in interests Set should be printed with all their info
       }
     });
 

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -347,16 +347,8 @@ public final class Chat {
             panels.push(createConversationPanel(conversation));
 
             // If this user isn't in the new conversations map, add them with a new Set
-            Set<Uuid> newConversations;
-            if (!newConversationsMap.containsKey(user.user.id)){
-              newConversations = new HashSet<>();
-            }
-            else { //if user already has Set of updated convos get it
-              newConversations = newConversationsMap.get(userPanelContext.user.id);
-            }
-
+            Set<Uuid> newConversations = newConversationsMap.computeIfAbsent(user.user.id, id -> new HashSet<>());
             newConversations.add(conversation.conversation.id);
-            newConversationsMap.put(user.user.id, newConversations);
 
             transactionLog.add(String.format("ADD-CONVERSATION %s %s \"%s\" %s",
                     conversation.conversation.id,
@@ -474,7 +466,7 @@ public final class Chat {
     panel.register("c-interest-remove", new Panel.Command() {
       @Override
       public void invoke(List<String> args){
-        final String name = args.size() > 0 ? String.join(" ", args) : "";
+        final String name = String.join(" ", args);
         if (name.length() > 0) {
           final ConversationContext conversation = findConversation(name);
           if (conversation == null) {
@@ -768,11 +760,9 @@ public final class Chat {
   }
 
   private void updateConversationsMap(Uuid user, Uuid convo){
-    Set<Uuid> conversations = (updatedConversationsMap.get(user) == null) ? new HashSet<>() : updatedConversationsMap.get(user);
+    Set<Uuid> conversations = updatedConversationsMap.computeIfAbsent(user, convoID -> new HashSet<>());
 
     conversations.add(convo);
-    updatedConversationsMap.put(user, conversations);
-
   }
 
   private void removeUpdatedConversation(Uuid user, Uuid convo) {
@@ -850,7 +840,7 @@ public final class Chat {
    }
 
   public void addUserInterest(Uuid userID, Uuid followedUserID){
-    Set<Uuid> userInterest = (userInterestMap.get(userID) == null) ? new HashSet<>() : userInterestMap.get(userID);
+    Set<Uuid> userInterest = userInterestMap.computeIfAbsent(userID, followedUser -> new HashSet<>());
 
     // Check if the user is trying to follow themselves
     if(userID.id() == followedUserID.id()) {

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -628,12 +628,8 @@ public final class Chat {
             System.out.format("Name: %s (UUID: %s)\n", followedConversation.conversation.title, followedConversation.conversation.id);
 
             // Get the message count contributed by ALL users
-            Integer totalMessageCount = 0;
-            for(UserContext users : rootPanelContext.allUsers())
-              totalMessageCount += (getMessageCount(users.user.id, followedConversationID) == null) ? 0 : getMessageCount(users.user.id, followedConversationID);
-
-            if(convoMessageCountsMap.get(user.user.id) != null)
-              System.out.format("\tMessages added since last update: %d\n", totalMessageCount);
+            Integer totalMessageCount = (getMessageCount(user.user.id, followedConversationID) == null) ? 0 : getMessageCount(user.user.id, followedConversationID);
+            System.out.format("\tMessages added since last update: %d\n", totalMessageCount);
 
           }
         }

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -187,7 +187,7 @@ public final class Chat {
     panel.register("u-list", new Panel.Command() {
       @Override
       public void invoke(List<String> args) {
-        for (final UserContext user : context.allUsers()) {
+        for (final UserContext user : context.allUsers().values()) {
           System.out.format(
               "USER %s (UUID: %s)\n",
               user.user.name,
@@ -349,6 +349,7 @@ public final class Chat {
             // If this user isn't in the new conversations map, add them with a new Set
             Set<Uuid> newConversations = newConversationsMap.computeIfAbsent(user.user.id, id -> new HashSet<>());
             newConversations.add(conversation.conversation.id);
+            newConversationsMap.put(user.user.id, newConversations);
 
             transactionLog.add(String.format("ADD-CONVERSATION %s %s \"%s\" %s",
                     conversation.conversation.id,
@@ -763,6 +764,7 @@ public final class Chat {
     Set<Uuid> conversations = updatedConversationsMap.computeIfAbsent(user, convoID -> new HashSet<>());
 
     conversations.add(convo);
+    updatedConversationsMap.put(user, conversations);
   }
 
   private void removeUpdatedConversation(Uuid user, Uuid convo) {
@@ -778,13 +780,12 @@ public final class Chat {
   // of a specific user.
   private void incrementMessageCount(Uuid convoID){
 
-    for(UserContext user : rootPanelContext.allUsers()){
+    for(UserContext user : rootPanelContext.allUsers().values()){
       HashMap<Uuid, Integer> convoCount = (convoMessageCountsMap.get(user.user.id) == null) ? new HashMap<>() : convoMessageCountsMap.get(user.user.id);
       Integer count = (convoCount.get(convoID) == null) ? 0 : convoCount.get(convoID);
 
       convoCount.put(convoID, count + 1);
       convoMessageCountsMap.put(user.user.id, convoCount);
-
     }
   }
 
@@ -798,7 +799,7 @@ public final class Chat {
   // Find the first user with the given name and return a user context
   // for that user. If no user is found, the function will return null.
   private UserContext findUser(String name) {
-    for (final UserContext user : rootPanelContext.allUsers()) {
+    for (final UserContext user : rootPanelContext.allUsers().values()) {
       if (user.user.name.equals(name)) {
         return user;
       }
@@ -809,12 +810,7 @@ public final class Chat {
   // Finds the first user with the given Uuid and returns a user context
   // for that user. If no user is found, the function will return null.
   private UserContext findUser(Uuid id) {
-    for (final UserContext user : rootPanelContext.allUsers()) {
-      if (user.user.id.equals(id)) {
-        return user;
-      }
-    }
-    return null;
+    return rootPanelContext.allUsers().get(id);
   }
 
   // Find the first conversation with the given name and return its context.
@@ -871,6 +867,7 @@ public final class Chat {
 
       HashMap<Uuid, Integer> followedConversations = convoMessageCountsMap.computeIfAbsent(userID, messageCount -> new HashMap<>());
       followedConversations.put(followedConvoID, 0);
+      convoMessageCountsMap.put(userID, followedConversations);
     }
   }
 

--- a/src/codeu/chat/client/core/Context.java
+++ b/src/codeu/chat/client/core/Context.java
@@ -16,10 +16,12 @@ package codeu.chat.client.core;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 
 import codeu.chat.common.BasicView;
 import codeu.chat.common.ServerInfo;
 import codeu.chat.common.User;
+import codeu.chat.util.Uuid;
 import codeu.chat.util.connections.ConnectionSource;
 
 public class Context {
@@ -39,10 +41,12 @@ public class Context {
         new UserContext(user, view, controller);
   }
 
-  public Iterable<UserContext> allUsers() {
-    final Collection<UserContext> users = new ArrayList<>();
-    for (final User user : view.getUsers()) {
-      users.add(new UserContext(user, view, controller));
+  public HashMap<Uuid, UserContext> allUsers() {
+
+    final HashMap<Uuid, UserContext> users = new HashMap<>();
+    for(final User user : view.getUsers()){
+      UserContext u = new UserContext(user, view, controller);
+      users.put(u.user.id, u);
     }
     return users;
   }

--- a/src/codeu/chat/client/core/Context.java
+++ b/src/codeu/chat/client/core/Context.java
@@ -14,14 +14,12 @@
 
 package codeu.chat.client.core;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 
 import codeu.chat.common.BasicView;
 import codeu.chat.common.ServerInfo;
 import codeu.chat.common.User;
-import codeu.chat.util.Uuid;
 import codeu.chat.util.connections.ConnectionSource;
 
 public class Context {
@@ -50,6 +48,6 @@ public class Context {
   }
 
   public ServerInfo getInfo() {
-    return ((View)view).getInfo();
+    return view.getInfo();
   }
 }

--- a/src/codeu/chat/client/core/Controller.java
+++ b/src/codeu/chat/client/core/Controller.java
@@ -14,9 +14,7 @@
 
 package codeu.chat.client.core;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.lang.Thread;
+import java.util.Collection;
 
 import codeu.chat.common.BasicController;
 import codeu.chat.common.ConversationHeader;

--- a/src/codeu/chat/client/core/UserContext.java
+++ b/src/codeu/chat/client/core/UserContext.java
@@ -16,6 +16,8 @@ package codeu.chat.client.core;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import codeu.chat.common.BasicController;
 import codeu.chat.common.BasicView;
@@ -29,17 +31,24 @@ public final class UserContext {
   private final BasicView view;
   private final BasicController controller;
 
+  // Keep track of new conversations
+  public Set<Uuid> newConversations;
+
   public UserContext(User user, BasicView view, BasicController controller) {
     this.user = user;
     this.view = view;
     this.controller = controller;
+    this.newConversations = new HashSet<>();
   }
 
   public ConversationContext start(String name) {
     final ConversationHeader conversation = controller.newConversation(name, user.id);
-    return conversation == null ?
-        null :
-        new ConversationContext(user, conversation, view, controller);
+
+    if(conversation != null){
+      newConversations.add(conversation.id);
+      return new ConversationContext(user, conversation, view, controller);
+    }
+    return null;
   }
 
   public Iterable<ConversationContext> conversations() {

--- a/src/codeu/chat/client/core/UserContext.java
+++ b/src/codeu/chat/client/core/UserContext.java
@@ -31,21 +31,20 @@ public final class UserContext {
   private final BasicView view;
   private final BasicController controller;
 
-  // Keep track of new conversations
   public Set<Uuid> newConversations;
 
   public UserContext(User user, BasicView view, BasicController controller) {
     this.user = user;
     this.view = view;
     this.controller = controller;
-    this.newConversations = new HashSet<>();
+
+    newConversations = new HashSet<>();
   }
 
   public ConversationContext start(String name) {
     final ConversationHeader conversation = controller.newConversation(name, user.id);
 
     if(conversation != null){
-      newConversations.add(conversation.id);
       return new ConversationContext(user, conversation, view, controller);
     }
     return null;
@@ -62,4 +61,5 @@ public final class UserContext {
 
     return all;
   }
+
 }

--- a/src/codeu/chat/client/core/UserContext.java
+++ b/src/codeu/chat/client/core/UserContext.java
@@ -14,10 +14,7 @@
 
 package codeu.chat.client.core;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import codeu.chat.common.BasicController;
 import codeu.chat.common.BasicView;
@@ -50,16 +47,21 @@ public final class UserContext {
     return null;
   }
 
-  public Iterable<ConversationContext> conversations() {
-
-    // Use all the ids to get all the conversations and convert them to
-    // Conversation Contexts.
-    final Collection<ConversationContext> all = new ArrayList<>();
-    for (final ConversationHeader conversation : view.getConversations()) {
-      all.add(new ConversationContext(user, conversation, view, controller));
+  public HashMap<Uuid, ConversationContext> conversations() {
+    final HashMap<Uuid, ConversationContext> conversations = new HashMap<>();
+    for(final ConversationHeader c : view.getConversations()){
+      conversations.put(c.id, new ConversationContext(user, c, view, controller));
     }
 
-    return all;
+    return conversations;
+//    // Use all the ids to get all the conversations and convert them to
+//    // Conversation Contexts.
+//    final Collection<ConversationContext> all = new ArrayList<>();
+//    for (final ConversationHeader conversation : view.getConversations()) {
+//      all.add(new ConversationContext(user, conversation, view, controller));
+//    }
+//
+//    return all;
   }
 
 }

--- a/src/codeu/chat/client/core/UserContext.java
+++ b/src/codeu/chat/client/core/UserContext.java
@@ -48,20 +48,15 @@ public final class UserContext {
   }
 
   public HashMap<Uuid, ConversationContext> conversations() {
+    // Use all the ids to get all the conversations and convert them to
+    // Conversation Contexts.
     final HashMap<Uuid, ConversationContext> conversations = new HashMap<>();
     for(final ConversationHeader c : view.getConversations()){
-      conversations.put(c.id, new ConversationContext(user, c, view, controller));
+      ConversationContext convo = new ConversationContext(user, c, view, controller);
+      conversations.put(convo.conversation.id, convo);
     }
 
     return conversations;
-//    // Use all the ids to get all the conversations and convert them to
-//    // Conversation Contexts.
-//    final Collection<ConversationContext> all = new ArrayList<>();
-//    for (final ConversationHeader conversation : view.getConversations()) {
-//      all.add(new ConversationContext(user, conversation, view, controller));
-//    }
-//
-//    return all;
   }
 
 }

--- a/src/codeu/chat/client/core/View.java
+++ b/src/codeu/chat/client/core/View.java
@@ -155,5 +155,4 @@ public class View implements BasicView {
     // If we get here it means something went wrong and null should be returned
     return null;
   }
-
 }

--- a/src/codeu/chat/common/BasicController.java
+++ b/src/codeu/chat/common/BasicController.java
@@ -16,6 +16,8 @@ package codeu.chat.common;
 
 import codeu.chat.util.Uuid;
 
+import java.util.Collection;
+
 // BASIC CONTROLLER
 //
 //   The controller component in the Model-View-Controller pattern. This
@@ -50,5 +52,4 @@ public interface BasicController {
   //  representing the full state of the conversation on the server.
   //  Whether conversations can have the same title is undefined.
   ConversationHeader newConversation(String title, Uuid owner);
-
 }

--- a/src/codeu/chat/common/BasicView.java
+++ b/src/codeu/chat/common/BasicView.java
@@ -51,4 +51,10 @@ public interface BasicView {
   //
   //   Return all messages whose id is found in the given collection.
   Collection<Message> getMessages(Collection<Uuid> ids);
+
+  // GET SERVER INFO
+  //
+  //  Return the current server information
+  ServerInfo getInfo();
+
 }

--- a/src/codeu/chat/common/ConversationHeader.java
+++ b/src/codeu/chat/common/ConversationHeader.java
@@ -54,6 +54,7 @@ public final class ConversationHeader {
   public final Uuid owner;
   public final Time creation;
   public final String title;
+
   //used to keep track of messages added to convo for interest system
   //TODO update this counter every time message is added if this convo is in interests of user
   //reset counter every time "status update" is called
@@ -65,6 +66,6 @@ public final class ConversationHeader {
     this.owner = owner;
     this.creation = creation;
     this.title = title;
-
+    this.messageCounter = 0;
   }
 }

--- a/src/codeu/chat/common/ConversationHeader.java
+++ b/src/codeu/chat/common/ConversationHeader.java
@@ -54,7 +54,6 @@ public final class ConversationHeader {
   public final Uuid owner;
   public final Time creation;
   public final String title;
-  public int messageCounter;
 
   public ConversationHeader(Uuid id, Uuid owner, Time creation, String title) {
 

--- a/src/codeu/chat/common/ConversationHeader.java
+++ b/src/codeu/chat/common/ConversationHeader.java
@@ -54,6 +54,10 @@ public final class ConversationHeader {
   public final Uuid owner;
   public final Time creation;
   public final String title;
+  //used to keep track of messages added to convo for interest system
+  //TODO update this counter every time message is added if this convo is in interests of user
+  //reset counter every time "status update" is called
+  public int messageCounter;
 
   public ConversationHeader(Uuid id, Uuid owner, Time creation, String title) {
 

--- a/src/codeu/chat/common/ConversationHeader.java
+++ b/src/codeu/chat/common/ConversationHeader.java
@@ -54,10 +54,6 @@ public final class ConversationHeader {
   public final Uuid owner;
   public final Time creation;
   public final String title;
-
-  //used to keep track of messages added to convo for interest system
-  //TODO update this counter every time message is added if this convo is in interests of user
-  //reset counter every time "status update" is called
   public int messageCounter;
 
   public ConversationHeader(Uuid id, Uuid owner, Time creation, String title) {
@@ -66,6 +62,5 @@ public final class ConversationHeader {
     this.owner = owner;
     this.creation = creation;
     this.title = title;
-    this.messageCounter = 0;
   }
 }

--- a/src/codeu/chat/common/ConversationHeader.java
+++ b/src/codeu/chat/common/ConversationHeader.java
@@ -54,11 +54,14 @@ public final class ConversationHeader {
   public final Time creation;
   public final String title;
 
+  public int messageCounter;
+
   public ConversationHeader(Uuid id, Uuid owner, Time creation, String title) {
 
     this.id = id;
     this.owner = owner;
     this.creation = creation;
     this.title = title;
+    this.messageCounter = 0;
   }
 }

--- a/src/codeu/chat/common/ConversationHeader.java
+++ b/src/codeu/chat/common/ConversationHeader.java
@@ -34,7 +34,6 @@ public final class ConversationHeader {
       Uuid.SERIALIZER.write(out, value.owner);
       Time.SERIALIZER.write(out, value.creation);
       Serializers.STRING.write(out, value.title);
-
     }
 
     @Override

--- a/src/codeu/chat/common/Message.java
+++ b/src/codeu/chat/common/Message.java
@@ -17,6 +17,7 @@ package codeu.chat.common;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Comparator;
 
 import codeu.chat.util.Serializer;
 import codeu.chat.util.Serializers;

--- a/src/codeu/chat/common/NetworkCode.java
+++ b/src/codeu/chat/common/NetworkCode.java
@@ -38,5 +38,4 @@ public final class NetworkCode {
       RELAY_WRITE_RESPONSE = 30,
       SERVER_INFO_REQUEST = 31,
       SERVER_INFO_RESPONSE = 32;
-
 }

--- a/src/codeu/chat/common/RawController.java
+++ b/src/codeu/chat/common/RawController.java
@@ -17,6 +17,8 @@ package codeu.chat.common;
 import codeu.chat.util.Time;
 import codeu.chat.util.Uuid;
 
+import java.util.Collection;
+
 // RAW CONTROLLER
 //
 // A controller that grants a large amount of control over how data is inserted

--- a/src/codeu/chat/common/ServerInfo.java
+++ b/src/codeu/chat/common/ServerInfo.java
@@ -1,10 +1,8 @@
 package codeu.chat.common;
 
-import codeu.chat.server.Server;
 import codeu.chat.util.Logger;
 import codeu.chat.util.Time;
 import codeu.chat.util.Uuid;
-import java.io.IOException;
 
 /**
  * Created by dita on 5/20/17.

--- a/src/codeu/chat/common/User.java
+++ b/src/codeu/chat/common/User.java
@@ -56,12 +56,6 @@ public final class User {
   public final String name;
   public final Time creation;
 
-  //set holding UuIDs of conversations that this user follows
-  public Set<Uuid> convoInterests = new HashSet<Uuid>();
-
-  //set holding UuIDs of users that this user follows
-  public Set<Uuid> userInterests = new HashSet<Uuid>();
-
   public User(Uuid id, String name, Time creation) {
 
     this.id = id;

--- a/src/codeu/chat/common/User.java
+++ b/src/codeu/chat/common/User.java
@@ -55,17 +55,12 @@ public final class User {
   public final Uuid id;
   public final String name;
   public final Time creation;
-<<<<<<< HEAD
 
-  //set holding Uuids of convos and users that this user follows
-  public Set<UserContext> userInterests = new HashSet<>();
-  public Set<ConversationContext> convoInterests = new HashSet<>();
-=======
   //set holding UuIDs of conversations that this user follows
   public Set<Uuid> convoInterests = new HashSet<Uuid>();
+
   //set holding UuIDs of users that this user follows
   public Set<Uuid> userInterests = new HashSet<Uuid>();
->>>>>>> b7388b8a9ab6f05cdf2e2599dc214432bb56d2fa
 
   public User(Uuid id, String name, Time creation) {
 

--- a/src/codeu/chat/common/User.java
+++ b/src/codeu/chat/common/User.java
@@ -20,6 +20,8 @@ import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.Set;
 
+import codeu.chat.client.core.ConversationContext;
+import codeu.chat.client.core.UserContext;
 import codeu.chat.util.Serializer;
 import codeu.chat.util.Serializers;
 import codeu.chat.util.Time;
@@ -53,14 +55,15 @@ public final class User {
   public final Uuid id;
   public final String name;
   public final Time creation;
-  //set holding UuIDs of convos and users that this user follows
-  public Set interests = new HashSet<Uuid>();
+
+  //set holding Uuids of convos and users that this user follows
+  public Set<UserContext> userInterests = new HashSet<>();
+  public Set<ConversationContext> convoInterests = new HashSet<>();
 
   public User(Uuid id, String name, Time creation) {
 
     this.id = id;
     this.name = name;
     this.creation = creation;
-
   }
 }

--- a/src/codeu/chat/common/User.java
+++ b/src/codeu/chat/common/User.java
@@ -53,8 +53,10 @@ public final class User {
   public final Uuid id;
   public final String name;
   public final Time creation;
-  //set holding UuIDs of convos and users that this user follows
-  public Set interests = new HashSet<Uuid>();
+  //set holding UuIDs of conversations that this user follows
+  public Set convoInterests = new HashSet<Uuid>();
+  //set holding UuIDs of users that this user follows
+  public Set userInterests = new HashSet<Uuid>();
 
   public User(Uuid id, String name, Time creation) {
 

--- a/src/codeu/chat/common/User.java
+++ b/src/codeu/chat/common/User.java
@@ -54,9 +54,9 @@ public final class User {
   public final String name;
   public final Time creation;
   //set holding UuIDs of conversations that this user follows
-  public Set convoInterests = new HashSet<Uuid>();
+  public Set<Uuid> convoInterests = new HashSet<Uuid>();
   //set holding UuIDs of users that this user follows
-  public Set userInterests = new HashSet<Uuid>();
+  public Set<Uuid> userInterests = new HashSet<Uuid>();
 
   public User(Uuid id, String name, Time creation) {
 

--- a/src/codeu/chat/common/User.java
+++ b/src/codeu/chat/common/User.java
@@ -17,6 +17,8 @@ package codeu.chat.common;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.HashSet;
+import java.util.Set;
 
 import codeu.chat.util.Serializer;
 import codeu.chat.util.Serializers;
@@ -51,6 +53,8 @@ public final class User {
   public final Uuid id;
   public final String name;
   public final Time creation;
+  //set holding UuIDs of convos and users that this user follows
+  public Set interests = new HashSet<Uuid>();
 
   public User(Uuid id, String name, Time creation) {
 

--- a/src/codeu/chat/common/User.java
+++ b/src/codeu/chat/common/User.java
@@ -17,6 +17,7 @@ package codeu.chat.common;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -45,7 +46,6 @@ public final class User {
           Serializers.STRING.read(in),
           Time.SERIALIZER.read(in)
       );
-
     }
   };
 
@@ -53,11 +53,13 @@ public final class User {
   public final String name;
   public final Time creation;
 
-  //set holding UuIDs of conversations that this user follows
+  // Set holding Uuids of conversations that this user follows
   public Set<Uuid> convoInterests;
 
-  //set holding UuIDs of users that this user follows
+  // Set holding Uuids of users that this user follows
   public Set<Uuid> userInterests;
+
+  public Set<Uuid> newConversations;
 
   public User(Uuid id, String name, Time creation) {
 
@@ -67,5 +69,7 @@ public final class User {
 
     this.convoInterests = new HashSet<>();
     this.userInterests = new HashSet<>();
+
+    this.newConversations = new HashSet<>();
   }
 }

--- a/src/codeu/chat/common/User.java
+++ b/src/codeu/chat/common/User.java
@@ -20,8 +20,6 @@ import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.Set;
 
-import codeu.chat.client.core.ConversationContext;
-import codeu.chat.client.core.UserContext;
 import codeu.chat.util.Serializer;
 import codeu.chat.util.Serializers;
 import codeu.chat.util.Time;
@@ -37,7 +35,6 @@ public final class User {
       Uuid.SERIALIZER.write(out, value.id);
       Serializers.STRING.write(out, value.name);
       Time.SERIALIZER.write(out, value.creation);
-
     }
 
     @Override
@@ -57,15 +54,18 @@ public final class User {
   public final Time creation;
 
   //set holding UuIDs of conversations that this user follows
-  public Set<Uuid> convoInterests = new HashSet<Uuid>();
+  public Set<Uuid> convoInterests;
 
   //set holding UuIDs of users that this user follows
-  public Set<Uuid> userInterests = new HashSet<Uuid>();
+  public Set<Uuid> userInterests;
 
   public User(Uuid id, String name, Time creation) {
 
     this.id = id;
     this.name = name;
     this.creation = creation;
+
+    this.convoInterests = new HashSet<>();
+    this.userInterests = new HashSet<>();
   }
 }

--- a/src/codeu/chat/server/Controller.java
+++ b/src/codeu/chat/server/Controller.java
@@ -15,6 +15,7 @@
 package codeu.chat.server;
 
 import java.util.Collection;
+import java.util.HashSet;
 
 import codeu.chat.common.BasicController;
 import codeu.chat.common.ConversationHeader;

--- a/src/codeu/chat/server/Model.java
+++ b/src/codeu/chat/server/Model.java
@@ -53,18 +53,9 @@ public final class Model {
 
   private static final Comparator<String> STRING_COMPARE = String.CASE_INSENSITIVE_ORDER;
 
-  private static final Comparator<Collection<Uuid>> COLLECTION_COMPARE = new Comparator<Collection<Uuid>>() {
-    @Override
-    public int compare(Collection<Uuid> o1, Collection<Uuid> o2) {
-      return Integer.compare(o1.size(), o2.size());
-    }
-  };
-
   private final Store<Uuid, User> userById = new Store<>(UUID_COMPARE);
   private final Store<Time, User> userByTime = new Store<>(TIME_COMPARE);
   private final Store<String, User> userByText = new Store<>(STRING_COMPARE);
-
-  private final Store<Collection<Uuid>, User> userByConvoInterest = new Store<>(COLLECTION_COMPARE);
 
   private final Store<Uuid, ConversationHeader> conversationById = new Store<>(UUID_COMPARE);
   private final Store<Time, ConversationHeader> conversationByTime = new Store<>(TIME_COMPARE);
@@ -80,8 +71,6 @@ public final class Model {
     userById.insert(user.id, user);
     userByTime.insert(user.creation, user);
     userByText.insert(user.name, user);
-
-    userByConvoInterest.insert(user.convoInterests, user);
   }
 
   public StoreAccessor<Uuid, User> userById() {
@@ -95,8 +84,6 @@ public final class Model {
   public StoreAccessor<String, User> userByText() {
     return userByText;
   }
-
-  public StoreAccessor<Collection<Uuid>, User> userByConvoInterest() { return userByConvoInterest; }
 
   public void add(ConversationHeader conversation) {
     conversationById.insert(conversation.id, conversation);

--- a/src/codeu/chat/server/Model.java
+++ b/src/codeu/chat/server/Model.java
@@ -14,11 +14,11 @@
 
 package codeu.chat.server;
 
+import java.util.Collection;
 import java.util.Comparator;
 
 import codeu.chat.common.ConversationHeader;
 import codeu.chat.common.ConversationPayload;
-import codeu.chat.common.LinearUuidGenerator;
 import codeu.chat.common.Message;
 import codeu.chat.common.User;
 import codeu.chat.util.Time;
@@ -53,9 +53,18 @@ public final class Model {
 
   private static final Comparator<String> STRING_COMPARE = String.CASE_INSENSITIVE_ORDER;
 
+  private static final Comparator<Collection<Uuid>> COLLECTION_COMPARE = new Comparator<Collection<Uuid>>() {
+    @Override
+    public int compare(Collection<Uuid> o1, Collection<Uuid> o2) {
+      return Integer.compare(o1.size(), o2.size());
+    }
+  };
+
   private final Store<Uuid, User> userById = new Store<>(UUID_COMPARE);
   private final Store<Time, User> userByTime = new Store<>(TIME_COMPARE);
   private final Store<String, User> userByText = new Store<>(STRING_COMPARE);
+
+  private final Store<Collection<Uuid>, User> userByConvoInterest = new Store<>(COLLECTION_COMPARE);
 
   private final Store<Uuid, ConversationHeader> conversationById = new Store<>(UUID_COMPARE);
   private final Store<Time, ConversationHeader> conversationByTime = new Store<>(TIME_COMPARE);
@@ -71,6 +80,8 @@ public final class Model {
     userById.insert(user.id, user);
     userByTime.insert(user.creation, user);
     userByText.insert(user.name, user);
+
+    userByConvoInterest.insert(user.convoInterests, user);
   }
 
   public StoreAccessor<Uuid, User> userById() {
@@ -84,6 +95,8 @@ public final class Model {
   public StoreAccessor<String, User> userByText() {
     return userByText;
   }
+
+  public StoreAccessor<Collection<Uuid>, User> userByConvoInterest() { return userByConvoInterest; }
 
   public void add(ConversationHeader conversation) {
     conversationById.insert(conversation.id, conversation);

--- a/src/codeu/chat/server/Server.java
+++ b/src/codeu/chat/server/Server.java
@@ -18,10 +18,7 @@ package codeu.chat.server;
 import java.io.*;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import codeu.chat.client.core.Context;
 import codeu.chat.common.*;
@@ -33,8 +30,6 @@ public final class Server {
   private interface Command {
     void onMessage(InputStream in, OutputStream out) throws IOException;
   }
-
-  private static final ServerInfo info = new ServerInfo();
 
   private static final Logger.Log LOG = Logger.newLog(Server.class);
 
@@ -176,7 +171,7 @@ public final class Server {
 
         // Write out server info response
         Serializers.INTEGER.write(out, NetworkCode.SERVER_INFO_RESPONSE);
-        Uuid.SERIALIZER.write(out, info.version);
+        Uuid.SERIALIZER.write(out, view.getInfo().version);
       }
     });
 

--- a/src/codeu/chat/server/View.java
+++ b/src/codeu/chat/server/View.java
@@ -15,26 +15,11 @@
 package codeu.chat.server;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
 
-import codeu.chat.common.BasicView;
-import codeu.chat.common.ConversationHeader;
-import codeu.chat.common.ConversationPayload;
-import codeu.chat.common.Message;
-import codeu.chat.common.SinglesView;
-import codeu.chat.common.User;
+import codeu.chat.common.*;
 import codeu.chat.util.Logger;
-import codeu.chat.util.Time;
 import codeu.chat.util.Uuid;
 import codeu.chat.util.store.StoreAccessor;
 
@@ -44,10 +29,11 @@ public final class View implements BasicView, SinglesView {
 
   private final Model model;
 
+  private static final ServerInfo info = new ServerInfo();
+
   public View(Model model) {
     this.model = model;
   }
-
 
   @Override
   public Collection<User> getUsers() {
@@ -62,6 +48,11 @@ public final class View implements BasicView, SinglesView {
   @Override
   public Collection<ConversationPayload> getConversationPayloads(Collection<Uuid> ids) {
     return intersect(model.conversationPayloadById(), ids);
+  }
+
+  @Override
+  public ServerInfo getInfo() {
+    return info;
   }
 
   @Override

--- a/test/codeu/chat/client/commandline/ChatTest.java
+++ b/test/codeu/chat/client/commandline/ChatTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -120,9 +121,9 @@ public final class ChatTest {
         }
 
         @Override
-        public Iterable<UserContext> allUsers() {
-            final Collection<UserContext> users = new ArrayList<>();
-            users.add(userContext);
+        public HashMap<Uuid, UserContext> allUsers() {
+            final HashMap<Uuid, UserContext> users = new HashMap<>();
+            users.put(userContext.user.id, userContext);
 
             return users;
         }


### PR DESCRIPTION
Users are now able to follow other users and conversations. 

The users/conversations someone is interested in are stored in HashMaps in the `Chat` class, and their respective activities are stored in other HashMaps - the `convoMessageCountsMap` stores information about the number of new messages a user sees, and the `newConversationsMap` and `updatedConversationsMap` stores the conversations a followed user creates and updates.

More client-side commands are added to reflect this interest system feature, including a `status-update` command that shows a user's following conversation/user activity since the last status update.

Interest systems of each user are also automatically re-loaded every new Server session, since the commands are logged into the `transaction_log` and recreated on startup.

Creating a comprehensive test for this feature poses the same File I/O difficulties of the tests supposed to be made for the persistent storage feature - further trials/research will be made to create some form of test for these new implementations in the future.