### PR TITLE
Access Control

### DIFF
--- a/src/codeu/chat/ClientMain.java
+++ b/src/codeu/chat/ClientMain.java
@@ -47,11 +47,12 @@ final class ClientMain {
 
       String commandType = logInfo.next();
 
+      // INTEREST SYSTEM
       if(commandType.equals("ADD-INTEREST-USER")){
         Uuid owner = Uuid.parse(logInfo.next());
         Uuid follow = Uuid.parse(logInfo.next());
 
-        chat.addUserInterest(owner, follow);
+        chat.addUserInterest(owner, follow, false);
       }
       else if(commandType.equals("REMOVE-INTEREST-USER")){
         Uuid owner = Uuid.parse(logInfo.next());
@@ -63,13 +64,51 @@ final class ClientMain {
         Uuid owner = Uuid.parse(logInfo.next());
         Uuid follow = Uuid.parse(logInfo.next());
 
-        chat.addConvoInterest(owner, follow);
+        chat.addConvoInterest(owner, follow, false);
       }
       else if(commandType.equals("REMOVE-INTEREST-CONVERSATION")){
         Uuid owner = Uuid.parse(logInfo.next());
         Uuid follow = Uuid.parse(logInfo.next());
 
         chat.removeConvoInterest(owner, follow);
+      }
+
+      // ACCESS CONTROL
+      else if(commandType.equals("ADD-CONVO-CREATOR")){
+        Uuid convo = Uuid.parse(logInfo.next());
+        Uuid user = Uuid.parse(logInfo.next());
+
+        chat.toggleUserToCreator(convo, user, true);
+      }
+      else if(commandType.equals("ADD-CONVO-MEMBER")){
+        Uuid convo = Uuid.parse(logInfo.next());
+        Uuid user = Uuid.parse(logInfo.next());
+
+        chat.toggleUserToMember(convo, user, true);
+      }
+      else if(commandType.equals("REMOVE-CONVO-MEMBER")){
+        Uuid convo = Uuid.parse(logInfo.next());
+        Uuid user = Uuid.parse(logInfo.next());
+
+        chat.toggleUserToMember(convo, user, false);
+      }
+      else if(commandType.equals("REMOVE-CONVO-TOGGLE")){
+        Uuid convo = Uuid.parse(logInfo.next());
+        Uuid user = Uuid.parse(logInfo.next());
+
+        chat.toggleRemoved(convo, user);
+      }
+      else if(commandType.equals("ADD-CONVO-OWNER")){
+        Uuid convo = Uuid.parse(logInfo.next());
+        Uuid user = Uuid.parse(logInfo.next());
+
+        chat.toggleUserToOwner(convo, user, true);
+      }
+      else if(commandType.equals("REMOVE-CONVO-OWNER")){
+        Uuid convo = Uuid.parse(logInfo.next());
+        Uuid user = Uuid.parse(logInfo.next());
+
+        chat.toggleUserToOwner(convo, user, false);
       }
     }
 

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -770,7 +770,7 @@ public final class Chat {
           if (removeUser == null) {
             System.out.format("ERROR: User '%s' does not exist.\n", name);
           } else {
-            //TODO set removeUser's member bit for this conversation to false
+            conversation.conversation.toggleUserToMember(removeUser.user, false);
           }
         } else {
           System.out.println("ERROR: Missing <username>");
@@ -794,7 +794,9 @@ public final class Chat {
           if (removedOwner == null) {
             System.out.format("ERROR: User '%s' does not exist.\n", name);
           } else {
-            //TODO set removedOwner's owner bit for this conversation to false
+            System.out.format("Owner bit - pre: %b\n", conversation.conversation.isOwner(removedOwner.user));
+            conversation.conversation.toggleUserToOwner(removedOwner.user, false);
+            System.out.format("Owner bit: %b\n", conversation.conversation.isOwner(removedOwner.user));
           }
         } else {
           System.out.println("ERROR: Missing <username>");
@@ -818,7 +820,9 @@ public final class Chat {
           if (addedOwner == null) {
             System.out.format("ERROR: User '%s' does not exist.\n", name);
           } else {
-            //TODO set removedOwner's owner bit for this conversation to true
+              System.out.format("Owner bit - pre: %b\n", conversation.conversation.isOwner(addedOwner.user));
+              conversation.conversation.toggleUserToOwner(addedOwner.user, true);
+              System.out.format("Owner bit: %b\n", conversation.conversation.isOwner(addedOwner.user));
           }
         } else {
           System.out.println("ERROR: Missing <username>");

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -23,16 +23,12 @@ import codeu.chat.client.core.MessageContext;
 import codeu.chat.client.core.UserContext;
 import codeu.chat.common.*;
 import codeu.chat.util.Tokenizer;
-import codeu.chat.util.Time;
 import codeu.chat.util.Uuid;
 
 public final class Chat {
 
   private static final File logFile = new File("data/transaction_log.txt");
   private static PrintWriter pw_log;
-
-  private static Time lastLogBackup;
-  private static final long BACKUP_RATE_IN_MS = 60000;
 
   //used to access Chat's users from outside the root panel
   private Context rootPanelContext;
@@ -58,7 +54,6 @@ public final class Chat {
   public Chat(Context context) {
 
     this.panels.push(createRootPanel(context));
-    lastLogBackup = Time.now();
 
     try {
       // Create a new transaction_log.txt file if needed - if not, this command does nothing
@@ -107,15 +102,6 @@ public final class Chat {
     final String command = args.get(0);
     args.remove(0);
 
-    // Evaluate if it is time to transfer data from queue to disk, then call the transferQueueToLog() method defined
-    // above and update the last backup time
-    Time currentTime = Time.now();
-    if(currentTime.inMs() - lastLogBackup.inMs() >= BACKUP_RATE_IN_MS){
-      transferQueueToLog();
-      lastLogBackup = currentTime;
-    }
-
-
     // Because "exit" and "back" are applicable to every panel, handle
     // those commands here to avoid having to implement them for each
     // panel.
@@ -163,6 +149,7 @@ public final class Chat {
   private Panel createRootPanel(final Context context) {
 
     final Panel panel = new Panel();
+    rootPanelContext = context;
 
     // HELP
     //
@@ -290,6 +277,7 @@ public final class Chat {
   private Panel createUserPanel(final UserContext user) {
 
     final Panel panel = new Panel();
+    userPanelContext = user;
 
     // HELP
     //

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -356,6 +356,8 @@ public final class Chat {
                     conversation.conversation.title,
                     conversation.conversation.creation.inMs()
             ));
+
+            //TODO set this user's creator, owner, and memeber bits to true for this conversation
           }
         } else {
           System.out.println("ERROR: Missing <title>");
@@ -378,6 +380,8 @@ public final class Chat {
             System.out.format("ERROR: No conversation with name '%s'\n", name);
           } else {
             panels.push(createConversationPanel(conversation));
+
+            //TODO set this user's member bit for this conversation as true (joining convo makes users a member)
           }
         } else {
           System.out.println("ERROR: Missing <title>");
@@ -676,6 +680,12 @@ public final class Chat {
         System.out.println("    List all messages in the current conversation.");
         System.out.println("  m-add <message>");
         System.out.println("    Add a new message to the current conversation as the current user.");
+        System.out.println("  u-remove-member <username>");
+        System.out.println("    Remove a member of the current conversation, can only be done by conversation owners or creator.");
+        System.out.println("  u-remove-owner <username>");
+        System.out.println("    Remove an owner of the current conversation, can only be done by conversation's creator.");
+        System.out.println("  u-add-owner <username>");
+        System.out.println("    Add an owner of the current conversation, can only be done by conversation's creator.");
         System.out.println("  info");
         System.out.println("    Display all info about the current conversation.");
         System.out.println("  back");
@@ -716,6 +726,10 @@ public final class Chat {
     panel.register("m-add", new Panel.Command() {
       @Override
       public void invoke(List<String> args) {
+        //TODO check if user is a member of conversation they're trying to add to
+        //if (user isn't member){
+        //System.out.println("ERROR: You are not a member of the conversation, and may not add a message.");
+        //return;}
         final String message = args.size() > 0 ? String.join(" ", args) : "";
         if (message.length() > 0) {
           MessageContext messageContext = conversation.add(message);
@@ -735,6 +749,78 @@ public final class Chat {
           )); //command message-id message-author message-content creation-time
         } else {
           System.out.println("ERROR: Messages must contain text");
+        }
+      }
+    });
+
+    // U-REMOVE-MEMBER (removes member from conversation)
+    //
+    // A user who's the conversation's owner or creator may use this command
+    // to remove a member/user from the conversation.
+    //
+    panel.register("u-remove-member", new Panel.Command() {
+      @Override
+      public void invoke(List<String> args) {
+        final String name = args.size() > 0 ? String.join(" ", args) : "";
+        //TODO check if user that calls this command is owner or creator of conversation, if not throw error
+
+        if (name.length() > 0) {
+          final UserContext removeUser = findUser(name);
+          if (removeUser == null) {
+            System.out.format("ERROR: User '%s' does not exist.\n", name);
+          } else {
+            //TODO set removeUser's member bit for this conversation to false
+          }
+        } else {
+          System.out.println("ERROR: Missing <username>");
+        }
+      }
+    });
+
+    // U-REMOVE-OWNER (removes owner of conversation)
+    //
+    // A user who's the conversation's creator may use this command
+    // to remove a user's owner status of the conversation.
+    //
+    panel.register("u-remove-owner", new Panel.Command() {
+      @Override
+      public void invoke(List<String> args) {
+        final String name = args.size() > 0 ? String.join(" ", args) : "";
+        //TODO check if user that calls this command creator of conversation, if not throw error
+
+        if (name.length() > 0) {
+          final UserContext removedOwner = findUser(name);
+          if (removedOwner == null) {
+            System.out.format("ERROR: User '%s' does not exist.\n", name);
+          } else {
+            //TODO set removedOwner's owner bit for this conversation to false
+          }
+        } else {
+          System.out.println("ERROR: Missing <username>");
+        }
+      }
+    });
+
+    // U-ADD-OWNER (removes owner of conversation)
+    //
+    // A user who's the conversation's creator may use this command
+    // to add owner status of the conversation to a user.
+    //
+    panel.register("u-add-owner", new Panel.Command() {
+      @Override
+      public void invoke(List<String> args) {
+        final String name = args.size() > 0 ? String.join(" ", args) : "";
+        //TODO check if user that calls this command creator of conversation, if not throw error
+
+        if (name.length() > 0) {
+          final UserContext addedOwner = findUser(name);
+          if (addedOwner == null) {
+            System.out.format("ERROR: User '%s' does not exist.\n", name);
+          } else {
+            //TODO set removedOwner's owner bit for this conversation to true
+          }
+        } else {
+          System.out.println("ERROR: Missing <username>");
         }
       }
     });

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -24,6 +24,7 @@ import codeu.chat.client.core.UserContext;
 import codeu.chat.common.*;
 import codeu.chat.util.Tokenizer;
 import codeu.chat.util.Time;
+import codeu.chat.util.Uuid;
 
 public final class Chat {
 
@@ -33,8 +34,10 @@ public final class Chat {
   private static Time lastLogBackup;
   private static final long BACKUP_RATE_IN_MS = 60000;
 
-  //used to access Chat's users from the user panel for interest system feature
+  //used to access Chat's users from outside the root panel
   private Context rootPanelContext;
+  //used to access Chat's conversations from outside the user panel
+  private UserContext userPanelContext;
 
   /**
    * ArrayDeque is a double-ended, self-resizing queue, used
@@ -246,17 +249,6 @@ public final class Chat {
           System.out.println("ERROR: Missing <username>");
         }
       }
-
-      // Find the first user with the given name and return a user context
-      // for that user. If no user is found, the function will return null.
-      private UserContext findUser(String name) {
-        for (final UserContext user : context.allUsers()) {
-          if (user.user.name.equals(name)) {
-            return user;
-          }
-        }
-        return null;
-      }
     });
 
     panel.register("info", new Panel.Command() {
@@ -282,6 +274,7 @@ public final class Chat {
   private Panel createUserPanel(final UserContext user) {
 
     final Panel panel = new Panel();
+    userPanelContext = user;
 
     // HELP
     //
@@ -412,22 +405,11 @@ public final class Chat {
             System.out.format("ERROR: No conversation with name '%s'\n", name);
           } else {
             //add specified conversation to user's interests
-            user.user.interests.add(conversation.conversation.id);
+            user.user.convoInterests.add(conversation.conversation.id);
           }
         } else {
           System.out.println("ERROR: Missing <title>");
         }
-      }
-
-      // Find the first conversation with the given name and return its context.
-      // If no conversation has the given name, this will return null.
-      private ConversationContext findConversation(String title) {
-        for (final ConversationContext conversation : user.conversations()) {
-          if (title.equals(conversation.conversation.title)) {
-            return conversation;
-          }
-        }
-        return null;
       }
     });
 
@@ -446,22 +428,11 @@ public final class Chat {
             System.out.format("ERROR: No conversation with name '%s'\n", name);
           } else {
             //if conversation is in interests it's removed, if not nothing is done
-            user.user.interests.remove(conversation.conversation.id);
+            user.user.convoInterests.remove(conversation.conversation.id);
           }
         } else {
           System.out.println("ERROR: Missing <title>");
         }
-      }
-
-      // Find the first conversation with the given name and return its context.
-      // If no conversation has the given name, this will return null.
-      private ConversationContext findConversation(String title) {
-        for (final ConversationContext conversation : user.conversations()) {
-          if (title.equals(conversation.conversation.title)) {
-            return conversation;
-          }
-        }
-        return null;
       }
     });
 
@@ -480,22 +451,11 @@ public final class Chat {
             System.out.format("ERROR: User '%s' does not exist.\n", name);
           } else {
             //adding specified user's Uuid to current user's interests
-            user.user.interests.add(interestUser.user.id);
+            user.user.userInteressts.add(interestUser.user.id);
           }
         } else {
           System.out.println("ERROR: Missing <username>");
         }
-      }
-
-      // Find the first user with the given name and return a user context
-      // for that user. If no user is found, the function will return null.
-      private UserContext findUser(String name) {
-        for (final UserContext user : rootPanelContext.allUsers()) {
-          if (user.user.name.equals(name)) {
-            return user;
-          }
-        }
-        return null;
       }
     });
 
@@ -514,22 +474,11 @@ public final class Chat {
             System.out.format("ERROR: User '%s' does not exist.\n", name);
           } else {
             //removing specified user from current user's interests
-            user.user.interests.remove(interestUser.user.id);
+            user.user.userInteressts.remove(interestUser.user.id);
           }
         } else {
           System.out.println("ERROR: Missing <username>");
         }
-      }
-
-      // Find the first user with the given name and return a user context
-      // for that user. If no user is found, the function will return null.
-      private UserContext findUser(String name) {
-        for (final UserContext user : rootPanelContext.allUsers()) {
-          if (user.user.name.equals(name)) {
-            return user;
-          }
-        }
-        return null;
       }
     });
 
@@ -665,5 +614,51 @@ public final class Chat {
     // Now that the panel has all its commands registered, return the panel
     // so that it can be used.
     return panel;
+  }
+
+  //methods below are helper methods to get a user or conversation from name or Uuid
+
+  // Find the first user with the given name and return a user context
+  // for that user. If no user is found, the function will return null.
+  private UserContext findUser(String name) {
+    for (final UserContext user : rootPanelContext.allUsers()) {
+      if (user.user.name.equals(name)) {
+        return user;
+      }
+    }
+    return null;
+  }
+
+  // Finds the first user with the given Uuid and returns a user context
+  // for that user. If no user is found, the function will return null.
+  private UserContext findUser(Uuid id) {
+    for (final UserContext user : rootPanelContext.allUsers()) {
+      if (user.user.id.equals(id)) {
+        return user;
+      }
+    }
+    return null;
+  }
+
+  // Find the first conversation with the given name and return its context.
+  // If no conversation has the given name, this will return null.
+  private ConversationContext findConversation(String title) {
+    for (final ConversationContext conversation : userPanelContext.conversations()) {
+      if (title.equals(conversation.conversation.title)) {
+        return conversation;
+      }
+    }
+    return null;
+  }
+
+  // Finds the first conversation with the given name and returns its context.
+  // If no conversation has the given name, this will return null.
+  private ConversationContext findConversation(Uuid id) {
+    for (final ConversationContext conversation : userPanelContext.conversations()) {
+      if (id.equals(conversation.conversation.id)) {
+        return conversation;
+      }
+    }
+    return null;
   }
 }

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -696,14 +696,18 @@ public final class Chat {
         System.out.println("    List all messages in the current conversation.");
         System.out.println("  m-add <message>");
         System.out.println("    Add a new message to the current conversation as the current user.");
+        System.out.println("  u-member-list");
+        System.out.println("    List all members in the current conversation.");
         System.out.println("  u-add-member <username>");
         System.out.println("    Add a member of the current conversation, can only be done by conversation owners or creator.");
         System.out.println("  u-remove-member <username>");
         System.out.println("    Remove a member of the current conversation, can only be done by conversation owners or creator.");
-        System.out.println("  u-remove-owner <username>");
-        System.out.println("    Remove an owner of the current conversation, can only be done by conversation's creator.");
+        System.out.println("  u-owner-list");
+        System.out.println("    List all members in the current conversation.");
         System.out.println("  u-add-owner <username>");
         System.out.println("    Add an owner of the current conversation, can only be done by conversation's creator.");
+        System.out.println("  u-remove-owner <username>");
+        System.out.println("    Remove an owner of the current conversation, can only be done by conversation's creator.");
         System.out.println("  my-access-status");
         System.out.println("    Display info about the current user's access control in the conversation.");
         System.out.println("  info");
@@ -774,6 +778,22 @@ public final class Chat {
       }
     });
 
+      // U-MEMBER-LIST
+      //
+      // List all members of the current conversation
+      //
+      panel.register("u-member-list", new Panel.Command() {
+        @Override
+        public void invoke(List<String> args) {
+          HashMap<Uuid, Integer> controls = getConversationAccessControl(conversation.conversation.id);
+          for(Uuid u : controls.keySet()){
+            UserContext user = findUser(u);
+            if(isMember(conversation, user.user))
+              System.out.format("Name: %s  (UUID: %s)\n", user.user.name, user.user.id);
+          }
+        }
+      });
+
       // U-ADD-MEMBER (adds member from conversation)
       //
       // A user who's the conversation's owner or creator may use this command
@@ -840,6 +860,22 @@ public final class Chat {
         }
         else {
           System.out.println("ERROR: Only users with owner or creator status\n can remove members from a conversation.");
+        }
+      }
+    });
+
+    // U-OWNER-LIST
+    //
+    // List all members of the current conversation
+    //
+    panel.register("u-owner-list", new Panel.Command() {
+      @Override
+      public void invoke(List<String> args) {
+        HashMap<Uuid, Integer> controls = getConversationAccessControl(conversation.conversation.id);
+        for(Uuid u : controls.keySet()){
+          UserContext user = findUser(u);
+          if(isOwner(conversation, user.user))
+            System.out.format("Name: %s  (UUID: %s)\n", user.user.name, user.user.id);
         }
       }
     });

--- a/src/codeu/chat/common/ConversationHeader.java
+++ b/src/codeu/chat/common/ConversationHeader.java
@@ -17,6 +17,7 @@ package codeu.chat.common;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.HashMap;
 
 import codeu.chat.util.Serializer;
@@ -72,7 +73,7 @@ public final class ConversationHeader {
   }
 
   // Flag is set to true if user is to be set to new status, else it's bit is 'turned off'
-  private void toggleUserToMember(User u, boolean flag){
+  public void toggleUserToMember(User u, boolean flag){
     Integer access = accessControls.computeIfAbsent(u.id, newAccess -> 0);
     Integer newAccess;
 
@@ -87,7 +88,7 @@ public final class ConversationHeader {
     accessControls.put(u.id, newAccess);
   }
 
-  private void toggleUserToOwner(User u, boolean flag){
+  public void toggleUserToOwner(User u, boolean flag){
     Integer access = accessControls.computeIfAbsent(u.id, newAccess -> 0);
     Integer newAccess;
 
@@ -104,7 +105,7 @@ public final class ConversationHeader {
     accessControls.put(u.id, newAccess);
   }
 
-  private void toggleUserToCreator(User u, boolean flag){
+  public void toggleUserToCreator(User u, boolean flag){
     Integer access = accessControls.computeIfAbsent(u.id, newAccess -> 0);
     Integer newAccess;
 
@@ -120,15 +121,15 @@ public final class ConversationHeader {
     accessControls.put(u.id, newAccess);
   }
 
-  private boolean isMember(User u){
+  public boolean isMember(User u){
     return accessControls.get(u.id) != null && (accessControls.get(u.id) & MEMBER) != 0;
   }
 
-  private boolean isOwner(User u){
+  public boolean isOwner(User u){
     return accessControls.get(u.id) != null && (accessControls.get(u.id) & OWNER) != 0;
   }
 
-  private boolean isCreator(User u){
+  public boolean isCreator(User u){
     return accessControls.get(u.id) != null && (accessControls.get(u.id) & CREATOR) != 0;
   }
 }

--- a/src/codeu/chat/common/ConversationHeader.java
+++ b/src/codeu/chat/common/ConversationHeader.java
@@ -54,6 +54,10 @@ public final class ConversationHeader {
   public final Uuid owner;
   public final Time creation;
   public final String title;
+  //used to keep track of messages added to convo for interest system
+  //TODO update this counter every time message is added if this convo is in interests of user
+  //reset counter every time "status update" is called
+  public int messageCounter;
 
   public ConversationHeader(Uuid id, Uuid owner, Time creation, String title) {
 

--- a/src/codeu/chat/common/ConversationHeader.java
+++ b/src/codeu/chat/common/ConversationHeader.java
@@ -61,6 +61,7 @@ public final class ConversationHeader {
   private static final int MEMBER = 0x0001;
   private static final int OWNER = 0x0002;
   private static final int CREATOR = 0x0004;
+  private static final int REMOVED = 0x0008;
 
   public ConversationHeader(Uuid id, Uuid owner, Time creation, String title) {
 
@@ -121,6 +122,17 @@ public final class ConversationHeader {
     accessControls.put(u.id, newAccess);
   }
 
+  // Flag is set to true if the user is removed from a conversation.
+  // Flag stays true once it's set.
+  public void toggleRemoved(User u){
+    Integer access = accessControls.computeIfAbsent(u.id, newAccess -> 0);
+    Integer newAccess;
+
+    newAccess = access | REMOVED;
+
+    accessControls.put(u.id, newAccess);
+  }
+
   public boolean isMember(User u){
     return accessControls.get(u.id) != null && (accessControls.get(u.id) & MEMBER) != 0;
   }
@@ -131,5 +143,9 @@ public final class ConversationHeader {
 
   public boolean isCreator(User u){
     return accessControls.get(u.id) != null && (accessControls.get(u.id) & CREATOR) != 0;
+  }
+
+  public boolean hasBeenRemoved(User u){
+    return accessControls.get(u.id) != null && (accessControls.get(u.id) & REMOVED) != 0;
   }
 }

--- a/src/codeu/chat/common/ConversationHeader.java
+++ b/src/codeu/chat/common/ConversationHeader.java
@@ -56,96 +56,11 @@ public final class ConversationHeader {
   public final Time creation;
   public final String title;
 
-  public HashMap<Uuid, Integer> accessControls;
-
-  private static final int MEMBER = 0x0001;
-  private static final int OWNER = 0x0002;
-  private static final int CREATOR = 0x0004;
-  private static final int REMOVED = 0x0008;
-
   public ConversationHeader(Uuid id, Uuid owner, Time creation, String title) {
 
     this.id = id;
     this.owner = owner;
     this.creation = creation;
     this.title = title;
-
-    accessControls = new HashMap<>();
-  }
-
-  // Flag is set to true if user is to be set to new status, else it's bit is 'turned off'
-  public void toggleUserToMember(User u, boolean flag){
-    Integer access = accessControls.computeIfAbsent(u.id, newAccess -> 0);
-    Integer newAccess;
-
-    if(flag)
-      newAccess = access | MEMBER;
-    // If member bit is to be 'turned off', also turn off it's parent controls
-    else {
-      newAccess = access & ~MEMBER;
-      toggleUserToOwner(u, false);
-      toggleUserToCreator(u, false);
-    }
-    accessControls.put(u.id, newAccess);
-  }
-
-  public void toggleUserToOwner(User u, boolean flag){
-    Integer access = accessControls.computeIfAbsent(u.id, newAccess -> 0);
-    Integer newAccess;
-
-    // If user is to be set as an Owner, it will also be it's children controls
-    if(flag){
-      newAccess = access | OWNER;
-      toggleUserToMember(u, true);
-    }
-    // If user is not an Owner anymore, it is also not it's parent controls anymore
-    else {
-      newAccess = access & ~OWNER;
-      toggleUserToCreator(u, false);
-    }
-    accessControls.put(u.id, newAccess);
-  }
-
-  public void toggleUserToCreator(User u, boolean flag){
-    Integer access = accessControls.computeIfAbsent(u.id, newAccess -> 0);
-    Integer newAccess;
-
-    // If user is to be set as a Creator, it will also be it's children controls
-    if(flag) {
-      newAccess = access | CREATOR;
-      toggleUserToOwner(u, true);
-      toggleUserToMember(u, true);
-    }
-    else
-      newAccess = access & ~CREATOR;
-
-    accessControls.put(u.id, newAccess);
-  }
-
-  // Flag is set to true if the user is removed from a conversation.
-  // Flag stays true once it's set.
-  public void toggleRemoved(User u){
-    Integer access = accessControls.computeIfAbsent(u.id, newAccess -> 0);
-    Integer newAccess;
-
-    newAccess = access | REMOVED;
-
-    accessControls.put(u.id, newAccess);
-  }
-
-  public boolean isMember(User u){
-    return accessControls.get(u.id) != null && (accessControls.get(u.id) & MEMBER) != 0;
-  }
-
-  public boolean isOwner(User u){
-    return accessControls.get(u.id) != null && (accessControls.get(u.id) & OWNER) != 0;
-  }
-
-  public boolean isCreator(User u){
-    return accessControls.get(u.id) != null && (accessControls.get(u.id) & CREATOR) != 0;
-  }
-
-  public boolean hasBeenRemoved(User u){
-    return accessControls.get(u.id) != null && (accessControls.get(u.id) & REMOVED) != 0;
   }
 }

--- a/src/codeu/chat/common/User.java
+++ b/src/codeu/chat/common/User.java
@@ -53,23 +53,10 @@ public final class User {
   public final String name;
   public final Time creation;
 
-  // Set holding Uuids of conversations that this user follows
-  public Set<Uuid> convoInterests;
-
-  // Set holding Uuids of users that this user follows
-  public Set<Uuid> userInterests;
-
-  public Set<Uuid> newConversations;
-
   public User(Uuid id, String name, Time creation) {
 
     this.id = id;
     this.name = name;
     this.creation = creation;
-
-    this.convoInterests = new HashSet<>();
-    this.userInterests = new HashSet<>();
-
-    this.newConversations = new HashSet<>();
   }
 }

--- a/src/codeu/chat/common/User.java
+++ b/src/codeu/chat/common/User.java
@@ -53,8 +53,10 @@ public final class User {
   public final Uuid id;
   public final String name;
   public final Time creation;
-  //set holding UuIDs of convos and users that this user follows
-  public Set interests = new HashSet<Uuid>();
+  //set holding UuIDs of conversations that this user follows
+  public Set convoInterests = new HashSet<Uuid>();
+  //set holding UuIDs of users that this user follows
+  public Set userInteressts = new HashSet<Uuid>();
 
   public User(Uuid id, String name, Time creation) {
 

--- a/src/codeu/chat/server/Model.java
+++ b/src/codeu/chat/server/Model.java
@@ -14,8 +14,8 @@
 
 package codeu.chat.server;
 
-import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 
 import codeu.chat.common.ConversationHeader;
 import codeu.chat.common.ConversationPayload;
@@ -53,6 +53,13 @@ public final class Model {
 
   private static final Comparator<String> STRING_COMPARE = String.CASE_INSENSITIVE_ORDER;
 
+  private static final Comparator<HashMap<Uuid, Integer>> HASH_MAP_COMPARATOR = new Comparator<HashMap<Uuid, Integer>>() {
+    @Override
+    public int compare(HashMap<Uuid, Integer> o1, HashMap<Uuid, Integer> o2) {
+      return Integer.compare(o1.size(), o2.size());
+    }
+  };
+
   private final Store<Uuid, User> userById = new Store<>(UUID_COMPARE);
   private final Store<Time, User> userByTime = new Store<>(TIME_COMPARE);
   private final Store<String, User> userByText = new Store<>(STRING_COMPARE);
@@ -60,6 +67,7 @@ public final class Model {
   private final Store<Uuid, ConversationHeader> conversationById = new Store<>(UUID_COMPARE);
   private final Store<Time, ConversationHeader> conversationByTime = new Store<>(TIME_COMPARE);
   private final Store<String, ConversationHeader> conversationByText = new Store<>(STRING_COMPARE);
+  private final Store<HashMap<Uuid, Integer>, ConversationHeader> conversationByAccessControl = new Store<>(HASH_MAP_COMPARATOR);
 
   private final Store<Uuid, ConversationPayload> conversationPayloadById = new Store<>(UUID_COMPARE);
 
@@ -90,6 +98,8 @@ public final class Model {
     conversationByTime.insert(conversation.creation, conversation);
     conversationByText.insert(conversation.title, conversation);
     conversationPayloadById.insert(conversation.id, new ConversationPayload(conversation.id));
+
+    conversationByAccessControl.insert(conversation.accessControls, conversation);
   }
 
   public StoreAccessor<Uuid, ConversationHeader> conversationById() {
@@ -107,6 +117,8 @@ public final class Model {
   public StoreAccessor<Uuid, ConversationPayload> conversationPayloadById() {
     return conversationPayloadById;
   }
+
+  public StoreAccessor<HashMap<Uuid, Integer>, ConversationHeader> conversationByAccessControl() { return conversationByAccessControl; }
 
   public void add(Message message) {
     messageById.insert(message.id, message);

--- a/src/codeu/chat/server/Model.java
+++ b/src/codeu/chat/server/Model.java
@@ -53,13 +53,6 @@ public final class Model {
 
   private static final Comparator<String> STRING_COMPARE = String.CASE_INSENSITIVE_ORDER;
 
-  private static final Comparator<HashMap<Uuid, Integer>> HASH_MAP_COMPARATOR = new Comparator<HashMap<Uuid, Integer>>() {
-    @Override
-    public int compare(HashMap<Uuid, Integer> o1, HashMap<Uuid, Integer> o2) {
-      return Integer.compare(o1.size(), o2.size());
-    }
-  };
-
   private final Store<Uuid, User> userById = new Store<>(UUID_COMPARE);
   private final Store<Time, User> userByTime = new Store<>(TIME_COMPARE);
   private final Store<String, User> userByText = new Store<>(STRING_COMPARE);
@@ -67,7 +60,6 @@ public final class Model {
   private final Store<Uuid, ConversationHeader> conversationById = new Store<>(UUID_COMPARE);
   private final Store<Time, ConversationHeader> conversationByTime = new Store<>(TIME_COMPARE);
   private final Store<String, ConversationHeader> conversationByText = new Store<>(STRING_COMPARE);
-  private final Store<HashMap<Uuid, Integer>, ConversationHeader> conversationByAccessControl = new Store<>(HASH_MAP_COMPARATOR);
 
   private final Store<Uuid, ConversationPayload> conversationPayloadById = new Store<>(UUID_COMPARE);
 
@@ -98,8 +90,6 @@ public final class Model {
     conversationByTime.insert(conversation.creation, conversation);
     conversationByText.insert(conversation.title, conversation);
     conversationPayloadById.insert(conversation.id, new ConversationPayload(conversation.id));
-
-    conversationByAccessControl.insert(conversation.accessControls, conversation);
   }
 
   public StoreAccessor<Uuid, ConversationHeader> conversationById() {
@@ -117,8 +107,6 @@ public final class Model {
   public StoreAccessor<Uuid, ConversationPayload> conversationPayloadById() {
     return conversationPayloadById;
   }
-
-  public StoreAccessor<HashMap<Uuid, Integer>, ConversationHeader> conversationByAccessControl() { return conversationByAccessControl; }
 
   public void add(Message message) {
     messageById.insert(message.id, message);

--- a/src/codeu/chat/server/View.java
+++ b/src/codeu/chat/server/View.java
@@ -16,6 +16,7 @@ package codeu.chat.server;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 
 import codeu.chat.common.*;
@@ -43,6 +44,10 @@ public final class View implements BasicView, SinglesView {
   @Override
   public Collection<ConversationHeader> getConversations() {
     return all(model.conversationById());
+  }
+
+  public Collection<ConversationHeader> getConversationAccessControls() {
+    return all(model.conversationByAccessControl());
   }
 
   @Override

--- a/src/codeu/chat/server/View.java
+++ b/src/codeu/chat/server/View.java
@@ -46,10 +46,6 @@ public final class View implements BasicView, SinglesView {
     return all(model.conversationById());
   }
 
-  public Collection<ConversationHeader> getConversationAccessControls() {
-    return all(model.conversationByAccessControl());
-  }
-
   @Override
   public Collection<ConversationPayload> getConversationPayloads(Collection<Uuid> ids) {
     return intersect(model.conversationPayloadById(), ids);

--- a/src/codeu/chat/util/Serializers.java
+++ b/src/codeu/chat/util/Serializers.java
@@ -19,6 +19,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 public final class Serializers {
 


### PR DESCRIPTION
Chat participants are now classified by specific access controls - member, owner, or creator. The control bits are stored in a `HashMap` in the `Chat` class - each conversation is mapped to another `HashMap` where the keys are user `Uuids` with an integer value storing the access control.

Access control modifications are dependent on the access control of the user making the change. These changes are all recorded in the transaction log and re-loaded when the server starts.